### PR TITLE
Update kubernetesmod to work with newer versions of the kubernetes python client

### DIFF
--- a/changelog/1.updated.md
+++ b/changelog/1.updated.md
@@ -1,3 +1,1 @@
-## [Unreleased]
-### Changed
-- Updated `kubernetesmod` to work with newer versions of the Kubernetes Python client.
+Updated `kubernetesmod` to work with newer versions of the Kubernetes Python client.

--- a/changelog/1.updated.md
+++ b/changelog/1.updated.md
@@ -1,0 +1,3 @@
+## [Unreleased]
+### Changed
+- Updated `kubernetesmod` to work with newer versions of the Kubernetes Python client.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ requires-python = ">= 3.9"
 dynamic = ["version"]
 dependencies = [
     "salt>=3006",
-    "kubernetes==3.0.0; platform_system == 'Linux'",
+    "kubernetes>=19.15.0; platform_system == 'Linux'",
 ]
 
 [project.readme]

--- a/src/saltext/kubernetes/modules/kubernetesmod.py
+++ b/src/saltext/kubernetes/modules/kubernetesmod.py
@@ -1465,7 +1465,10 @@ def __dict_to_deployment_spec(spec):
     """
     Converts a dictionary into kubernetes V1DeploymentSpec instance.
     """
-    spec_obj = V1DeploymentSpec(template=spec.get("template", ""))
+    spec_obj = V1DeploymentSpec(
+        template=spec.get("template", ""),
+        selector=spec.get("selector", {"matchLabels": {"app": "default"}}),
+    )
     for key, value in spec.items():
         if hasattr(spec_obj, key):
             setattr(spec_obj, key, value)

--- a/src/saltext/kubernetes/modules/kubernetesmod.py
+++ b/src/saltext/kubernetes/modules/kubernetesmod.py
@@ -444,7 +444,7 @@ def deployments(namespace="default", **kwargs):
     """
     cfg = _setup_conn(**kwargs)
     try:
-        api_instance = kubernetes.client.ExtensionsV1Api()
+        api_instance = kubernetes.client.AppsV1Api()
         api_response = api_instance.list_namespaced_deployment(namespace)
 
         return [dep["metadata"]["name"] for dep in api_response.to_dict().get("items")]
@@ -452,7 +452,7 @@ def deployments(namespace="default", **kwargs):
         if isinstance(exc, ApiException) and exc.status == 404:
             return None
         else:
-            log.exception("Exception when calling ExtensionsV1Api->list_namespaced_deployment")
+            log.exception("Exception when calling AppsV1Api->list_namespaced_deployment")
             raise CommandExecutionError(exc)
     finally:
         _cleanup(**cfg)
@@ -579,7 +579,7 @@ def show_deployment(name, namespace="default", **kwargs):
     """
     cfg = _setup_conn(**kwargs)
     try:
-        api_instance = kubernetes.client.ExtensionsV1Api()
+        api_instance = kubernetes.client.AppsV1Api()
         api_response = api_instance.read_namespaced_deployment(name, namespace)
 
         return api_response.to_dict()
@@ -587,7 +587,7 @@ def show_deployment(name, namespace="default", **kwargs):
         if isinstance(exc, ApiException) and exc.status == 404:
             return None
         else:
-            log.exception("Exception when calling ExtensionsV1Api->read_namespaced_deployment")
+            log.exception("Exception when calling AppsV1Api->read_namespaced_deployment")
             raise CommandExecutionError(exc)
     finally:
         _cleanup(**cfg)
@@ -750,7 +750,7 @@ def delete_deployment(name, namespace="default", **kwargs):
     body = kubernetes.client.V1DeleteOptions(orphan_dependents=True)
 
     try:
-        api_instance = kubernetes.client.ExtensionsV1Api()
+        api_instance = kubernetes.client.AppsV1Api()
         api_response = api_instance.delete_namespaced_deployment(
             name=name, namespace=namespace, body=body
         )
@@ -783,7 +783,7 @@ def delete_deployment(name, namespace="default", **kwargs):
         if isinstance(exc, ApiException) and exc.status == 404:
             return None
         else:
-            log.exception("Exception when calling ExtensionsV1Api->delete_namespaced_deployment")
+            log.exception("Exception when calling AppsV1Api->delete_namespaced_deployment")
             raise CommandExecutionError(exc)
     finally:
         _cleanup(**cfg)
@@ -962,7 +962,7 @@ def create_deployment(name, namespace, metadata, spec, source, template, saltenv
     cfg = _setup_conn(**kwargs)
 
     try:
-        api_instance = kubernetes.client.ExtensionsV1Api()
+        api_instance = kubernetes.client.AppsV1Api()
         api_response = api_instance.create_namespaced_deployment(namespace, body)
 
         return api_response.to_dict()
@@ -970,7 +970,7 @@ def create_deployment(name, namespace, metadata, spec, source, template, saltenv
         if isinstance(exc, ApiException) and exc.status == 404:
             return None
         else:
-            log.exception("Exception when calling ExtensionsV1Api->create_namespaced_deployment")
+            log.exception("Exception when calling AppsV1Api->create_namespaced_deployment")
             raise CommandExecutionError(exc)
     finally:
         _cleanup(**cfg)
@@ -1208,7 +1208,7 @@ def replace_deployment(
     cfg = _setup_conn(**kwargs)
 
     try:
-        api_instance = kubernetes.client.ExtensionsV1Api()
+        api_instance = kubernetes.client.AppsV1Api()
         api_response = api_instance.replace_namespaced_deployment(name, namespace, body)
 
         return api_response.to_dict()
@@ -1216,7 +1216,7 @@ def replace_deployment(
         if isinstance(exc, ApiException) and exc.status == 404:
             return None
         else:
-            log.exception("Exception when calling ExtensionsV1Api->replace_namespaced_deployment")
+            log.exception("Exception when calling AppsV1Api->replace_namespaced_deployment")
             raise CommandExecutionError(exc)
     finally:
         _cleanup(**cfg)

--- a/src/saltext/kubernetes/modules/kubernetesmod.py
+++ b/src/saltext/kubernetes/modules/kubernetesmod.py
@@ -2,7 +2,7 @@
 """
 Module for handling kubernetes calls.
 
-:optdepends:    - kubernetes Python client >= v22.0
+:optdepends:    - kubernetes Python client >= v19.15.0
                 - PyYAML >= 5.3.1
 :configuration: The k8s API settings are provided either in a pillar, in
     the minion's config file, or in master's config file::

--- a/tests/unit/modules/test_kubernetesmod.py
+++ b/tests/unit/modules/test_kubernetesmod.py
@@ -74,7 +74,7 @@ def test_deployments():
     :return:
     """
     with mock_kubernetes_library() as mock_kubernetes_lib:
-        mock_kubernetes_lib.client.ExtensionsV1beta1Api.return_value = Mock(
+        mock_kubernetes_lib.client.ExtensionsV1Api.return_value = Mock(
             **{
                 "list_namespaced_deployment.return_value.to_dict.return_value": {
                     "items": [{"metadata": {"name": "mock_deployment_name"}}]
@@ -84,7 +84,7 @@ def test_deployments():
         assert kubernetes.deployments() == ["mock_deployment_name"]
         # py#int: disable=E1120
         assert (
-            kubernetes.kubernetes.client.ExtensionsV1beta1Api()
+            kubernetes.kubernetes.client.ExtensionsV1Api()
             .list_namespaced_deployment()
             .to_dict.called
         )
@@ -134,12 +134,12 @@ def test_delete_deployments():
             "saltext.kubernetes.modules.kubernetesmod.show_deployment", Mock(return_value=None)
         ):
             mock_kubernetes_lib.client.V1DeleteOptions = Mock(return_value="")
-            mock_kubernetes_lib.client.ExtensionsV1beta1Api.return_value = Mock(
+            mock_kubernetes_lib.client.ExtensionsV1Api.return_value = Mock(
                 **{"delete_namespaced_deployment.return_value.to_dict.return_value": {"code": ""}}
             )
             assert kubernetes.delete_deployment("test") == {"code": 200}
             assert (
-                kubernetes.kubernetes.client.ExtensionsV1beta1Api()
+                kubernetes.kubernetes.client.ExtensionsV1Api()
                 .delete_namespaced_deployment()
                 .to_dict.called
             )
@@ -151,12 +151,12 @@ def test_create_deployments():
     :return:
     """
     with mock_kubernetes_library() as mock_kubernetes_lib:
-        mock_kubernetes_lib.client.ExtensionsV1beta1Api.return_value = Mock(
+        mock_kubernetes_lib.client.ExtensionsV1Api.return_value = Mock(
             **{"create_namespaced_deployment.return_value.to_dict.return_value": {}}
         )
         assert kubernetes.create_deployment("test", "default", {}, {}, None, None, None) == {}
         assert (
-            kubernetes.kubernetes.client.ExtensionsV1beta1Api()
+            kubernetes.kubernetes.client.ExtensionsV1Api()
             .create_namespaced_deployment()
             .to_dict.called
         )

--- a/tests/unit/modules/test_kubernetesmod.py
+++ b/tests/unit/modules/test_kubernetesmod.py
@@ -74,7 +74,7 @@ def test_deployments():
     :return:
     """
     with mock_kubernetes_library() as mock_kubernetes_lib:
-        mock_kubernetes_lib.client.ExtensionsV1Api.return_value = Mock(
+        mock_kubernetes_lib.client.AppsV1Api.return_value = Mock(
             **{
                 "list_namespaced_deployment.return_value.to_dict.return_value": {
                     "items": [{"metadata": {"name": "mock_deployment_name"}}]
@@ -83,11 +83,7 @@ def test_deployments():
         )
         assert kubernetes.deployments() == ["mock_deployment_name"]
         # py#int: disable=E1120
-        assert (
-            kubernetes.kubernetes.client.ExtensionsV1Api()
-            .list_namespaced_deployment()
-            .to_dict.called
-        )
+        assert kubernetes.kubernetes.client.AppsV1Api().list_namespaced_deployment().to_dict.called
 
 
 def test_services():
@@ -134,12 +130,12 @@ def test_delete_deployments():
             "saltext.kubernetes.modules.kubernetesmod.show_deployment", Mock(return_value=None)
         ):
             mock_kubernetes_lib.client.V1DeleteOptions = Mock(return_value="")
-            mock_kubernetes_lib.client.ExtensionsV1Api.return_value = Mock(
+            mock_kubernetes_lib.client.AppsV1Api.return_value = Mock(
                 **{"delete_namespaced_deployment.return_value.to_dict.return_value": {"code": ""}}
             )
             assert kubernetes.delete_deployment("test") == {"code": 200}
             assert (
-                kubernetes.kubernetes.client.ExtensionsV1Api()
+                kubernetes.kubernetes.client.AppsV1Api()
                 .delete_namespaced_deployment()
                 .to_dict.called
             )
@@ -151,14 +147,12 @@ def test_create_deployments():
     :return:
     """
     with mock_kubernetes_library() as mock_kubernetes_lib:
-        mock_kubernetes_lib.client.ExtensionsV1Api.return_value = Mock(
+        mock_kubernetes_lib.client.AppsV1Api.return_value = Mock(
             **{"create_namespaced_deployment.return_value.to_dict.return_value": {}}
         )
         assert kubernetes.create_deployment("test", "default", {}, {}, None, None, None) == {}
         assert (
-            kubernetes.kubernetes.client.ExtensionsV1Api()
-            .create_namespaced_deployment()
-            .to_dict.called
+            kubernetes.kubernetes.client.AppsV1Api().create_namespaced_deployment().to_dict.called
         )
 
 


### PR DESCRIPTION
…entSpec

### What does this PR do?
This PR updates the `kubernetesmod.py` module to function with newer versions of the Kubernetes Python client.

### What issues does this PR fix or reference?
Fixes: #5 

### Previous Behavior
The module did not support newer versions of the Kubernetes Python client.

### New Behavior
The module now supports newer versions of the Kubernetes Python client.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
