### PR TITLE
[Feature] add support for context variables for better use of templating

### DIFF
--- a/changelog/1.updated.md
+++ b/changelog/1.updated.md
@@ -1,0 +1,3 @@
+## [Unreleased]
+### Changed
+- Updated `kubernetesmod` to work with newer versions of the Kubernetes Python client.

--- a/changelog/2.feature.md
+++ b/changelog/2.feature.md
@@ -1,0 +1,5 @@
+## [Unreleased]
+
+### Added
+- Added support for using context in templates for `deployment_present`, `service_present`, `configmap_present`, and `secret_present` states.
+- Added unit tests to support the new context feature.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ requires-python = ">= 3.9"
 dynamic = ["version"]
 dependencies = [
     "salt>=3006",
-    "kubernetes>=19.15.0; platform_system == 'Linux'",
+    "kubernetes>=22.0; platform_system == 'Linux'",
+    "PyYAML>=5.3.1",
 ]
 
 [project.readme]
@@ -71,11 +72,14 @@ lint = [
 ]
 tests = [
     "pytest>=7.2.0",
-    "pytest-salt-factories>=1.0.0",
-    "pytest-custom-exit-code>=0.3",
+    "pytest-salt-factories>=1.0.0rc19",
     "pytest-helpers-namespace>=2019.1.8",
     "pytest-subtests",
     "pytest-timeout",
+    "kubernetes>=22.0",
+    "PyYAML>=5.3.1",
+    "mock>=4.0.3",
+    "pytest-custom-exit-code>=0.3",
 ]
 
 [project.entry-points."salt.loader"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ requires-python = ">= 3.9"
 dynamic = ["version"]
 dependencies = [
     "salt>=3006",
-    "kubernetes==3.0.0; platform_system == 'Linux'",
+    "kubernetes>=19.15.0; platform_system == 'Linux'",
 ]
 
 [project.readme]

--- a/src/saltext/kubernetes/modules/kubernetesmod.py
+++ b/src/saltext/kubernetes/modules/kubernetesmod.py
@@ -1465,7 +1465,10 @@ def __dict_to_deployment_spec(spec):
     """
     Converts a dictionary into kubernetes V1DeploymentSpec instance.
     """
-    spec_obj = V1DeploymentSpec(template=spec.get("template", ""))
+    spec_obj = V1DeploymentSpec(
+        template=spec.get("template", ""),
+        selector=spec.get("selector", {"matchLabels": {"app": "default"}}),
+    )
     for key, value in spec.items():
         if hasattr(spec_obj, key):
             setattr(spec_obj, key, value)

--- a/src/saltext/kubernetes/modules/kubernetesmod.py
+++ b/src/saltext/kubernetes/modules/kubernetesmod.py
@@ -444,7 +444,7 @@ def deployments(namespace="default", **kwargs):
     """
     cfg = _setup_conn(**kwargs)
     try:
-        api_instance = kubernetes.client.ExtensionsV1Api()
+        api_instance = kubernetes.client.AppsV1Api()
         api_response = api_instance.list_namespaced_deployment(namespace)
 
         return [dep["metadata"]["name"] for dep in api_response.to_dict().get("items")]
@@ -452,7 +452,7 @@ def deployments(namespace="default", **kwargs):
         if isinstance(exc, ApiException) and exc.status == 404:
             return None
         else:
-            log.exception("Exception when calling ExtensionsV1Api->list_namespaced_deployment")
+            log.exception("Exception when calling AppsV1Api->list_namespaced_deployment")
             raise CommandExecutionError(exc)
     finally:
         _cleanup(**cfg)
@@ -579,7 +579,7 @@ def show_deployment(name, namespace="default", **kwargs):
     """
     cfg = _setup_conn(**kwargs)
     try:
-        api_instance = kubernetes.client.ExtensionsV1Api()
+        api_instance = kubernetes.client.AppsV1Api()
         api_response = api_instance.read_namespaced_deployment(name, namespace)
 
         return api_response.to_dict()
@@ -587,7 +587,7 @@ def show_deployment(name, namespace="default", **kwargs):
         if isinstance(exc, ApiException) and exc.status == 404:
             return None
         else:
-            log.exception("Exception when calling ExtensionsV1Api->read_namespaced_deployment")
+            log.exception("Exception when calling AppsV1Api->read_namespaced_deployment")
             raise CommandExecutionError(exc)
     finally:
         _cleanup(**cfg)
@@ -750,7 +750,7 @@ def delete_deployment(name, namespace="default", **kwargs):
     body = kubernetes.client.V1DeleteOptions(orphan_dependents=True)
 
     try:
-        api_instance = kubernetes.client.ExtensionsV1Api()
+        api_instance = kubernetes.client.AppsV1Api()
         api_response = api_instance.delete_namespaced_deployment(
             name=name, namespace=namespace, body=body
         )
@@ -783,7 +783,7 @@ def delete_deployment(name, namespace="default", **kwargs):
         if isinstance(exc, ApiException) and exc.status == 404:
             return None
         else:
-            log.exception("Exception when calling ExtensionsV1Api->delete_namespaced_deployment")
+            log.exception("Exception when calling AppsV1Api->delete_namespaced_deployment")
             raise CommandExecutionError(exc)
     finally:
         _cleanup(**cfg)
@@ -962,7 +962,7 @@ def create_deployment(name, namespace, metadata, spec, source, template, saltenv
     cfg = _setup_conn(**kwargs)
 
     try:
-        api_instance = kubernetes.client.ExtensionsV1Api()
+        api_instance = kubernetes.client.AppsV1Api()
         api_response = api_instance.create_namespaced_deployment(namespace, body)
 
         return api_response.to_dict()
@@ -970,7 +970,7 @@ def create_deployment(name, namespace, metadata, spec, source, template, saltenv
         if isinstance(exc, ApiException) and exc.status == 404:
             return None
         else:
-            log.exception("Exception when calling ExtensionsV1Api->create_namespaced_deployment")
+            log.exception("Exception when calling AppsV1Api->create_namespaced_deployment")
             raise CommandExecutionError(exc)
     finally:
         _cleanup(**cfg)
@@ -1208,7 +1208,7 @@ def replace_deployment(
     cfg = _setup_conn(**kwargs)
 
     try:
-        api_instance = kubernetes.client.ExtensionsV1Api()
+        api_instance = kubernetes.client.AppsV1Api()
         api_response = api_instance.replace_namespaced_deployment(name, namespace, body)
 
         return api_response.to_dict()
@@ -1216,7 +1216,7 @@ def replace_deployment(
         if isinstance(exc, ApiException) and exc.status == 404:
             return None
         else:
-            log.exception("Exception when calling ExtensionsV1Api->replace_namespaced_deployment")
+            log.exception("Exception when calling AppsV1Api->replace_namespaced_deployment")
             raise CommandExecutionError(exc)
     finally:
         _cleanup(**cfg)

--- a/src/saltext/kubernetes/states/kubernetesmod.py
+++ b/src/saltext/kubernetes/states/kubernetesmod.py
@@ -67,6 +67,30 @@ The kubernetes module is used to manage different kubernetes resources.
       require:
         - pip: kubernetes-python-module
 
+    # kubernetes deployment using a template with custom context variables
+    nginx-template-with-context:
+      kubernetes.deployment_present:
+        - name: nginx-template
+        - source: salt://k8s/nginx-template.yml.jinja
+        - template: jinja
+        - context:
+            replicas: 3
+            nginx_version: 1.19
+            environment: production
+            app_label: frontend
+
+    # kubernetes secret with context variables
+    cert-secret-with-context:
+      kubernetes.secret_present:
+        - name: tls-cert
+        - source: salt://k8s/tls-cert.yml.jinja
+        - template: jinja
+        - context:
+            cert_name: myapp.example.com
+            cert_data: |
+                -----BEGIN CERTIFICATE-----
+                ...
+                -----END CERTIFICATE-----
 
     # Kubernetes secret
     k8s-secret:
@@ -321,7 +345,7 @@ def service_present(
             template=template,
             old_service=service,
             saltenv=__env__,
-            context=context,  # Pass context parameter
+            context=context,
             **kwargs,
         )
 

--- a/src/saltext/kubernetes/states/kubernetesmod.py
+++ b/src/saltext/kubernetes/states/kubernetesmod.py
@@ -144,7 +144,14 @@ def deployment_absent(name, namespace="default", **kwargs):
 
 
 def deployment_present(
-    name, namespace="default", metadata=None, spec=None, source="", template="", **kwargs
+    name,
+    namespace="default",
+    metadata=None,
+    spec=None,
+    source="",
+    template="",
+    context=None,
+    **kwargs,
 ):
     """
     Ensures that the named deployment is present inside of the specified
@@ -170,6 +177,9 @@ def deployment_present(
 
     template
         Template engine to be used to render the source file.
+
+    context
+        Variables to be passed into the template.
     """
     ret = {"name": name, "changes": {}, "result": False, "comment": ""}
 
@@ -197,6 +207,7 @@ def deployment_present(
             source=source,
             template=template,
             saltenv=__env__,
+            context=context,
             **kwargs,
         )
         ret["changes"][f"{namespace}.{name}"] = {"old": {}, "new": res}
@@ -216,6 +227,7 @@ def deployment_present(
             source=source,
             template=template,
             saltenv=__env__,
+            context=context,
             **kwargs,
         )
 
@@ -225,7 +237,14 @@ def deployment_present(
 
 
 def service_present(
-    name, namespace="default", metadata=None, spec=None, source="", template="", **kwargs
+    name,
+    namespace="default",
+    metadata=None,
+    spec=None,
+    source="",
+    template="",
+    context=None,
+    **kwargs,
 ):
     """
     Ensures that the named service is present inside of the specified namespace
@@ -251,6 +270,9 @@ def service_present(
 
     template
         Template engine to be used to render the source file.
+
+    context
+        Variables to be passed into the template.
     """
     ret = {"name": name, "changes": {}, "result": False, "comment": ""}
 
@@ -278,6 +300,7 @@ def service_present(
             source=source,
             template=template,
             saltenv=__env__,
+            context=context,
             **kwargs,
         )
         ret["changes"][f"{namespace}.{name}"] = {"old": {}, "new": res}
@@ -298,6 +321,7 @@ def service_present(
             template=template,
             old_service=service,
             saltenv=__env__,
+            context=context,  # Pass context parameter
             **kwargs,
         )
 
@@ -446,7 +470,9 @@ def secret_absent(name, namespace="default", **kwargs):
     return ret
 
 
-def secret_present(name, namespace="default", data=None, source=None, template=None, **kwargs):
+def secret_present(
+    name, namespace="default", data=None, source=None, template=None, context=None, **kwargs
+):
     """
     Ensures that the named secret is present inside of the specified namespace
     with the given data.
@@ -467,6 +493,9 @@ def secret_present(name, namespace="default", data=None, source=None, template=N
 
     template
         Template engine to be used to render the source file.
+
+    context
+        Variables to be passed into the template.
     """
     ret = {"name": name, "changes": {}, "result": False, "comment": ""}
 
@@ -490,6 +519,7 @@ def secret_present(name, namespace="default", data=None, source=None, template=N
             source=source,
             template=template,
             saltenv=__env__,
+            context=context,
             **kwargs,
         )
         ret["changes"][f"{namespace}.{name}"] = {"old": {}, "new": res}
@@ -509,6 +539,7 @@ def secret_present(name, namespace="default", data=None, source=None, template=N
             source=source,
             template=template,
             saltenv=__env__,
+            context=context,
             **kwargs,
         )
 
@@ -559,7 +590,9 @@ def configmap_absent(name, namespace="default", **kwargs):
     return ret
 
 
-def configmap_present(name, namespace="default", data=None, source=None, template=None, **kwargs):
+def configmap_present(
+    name, namespace="default", data=None, source=None, template=None, context=None, **kwargs
+):
     """
     Ensures that the named configmap is present inside of the specified namespace
     with the given data.
@@ -580,6 +613,9 @@ def configmap_present(name, namespace="default", data=None, source=None, templat
 
     template
         Template engine to be used to render the source file.
+
+    context
+        Variables to be passed into the template.
     """
     ret = {"name": name, "changes": {}, "result": False, "comment": ""}
 
@@ -602,6 +638,7 @@ def configmap_present(name, namespace="default", data=None, source=None, templat
             source=source,
             template=template,
             saltenv=__env__,
+            context=context,
             **kwargs,
         )
         ret["changes"][f"{namespace}.{name}"] = {"old": {}, "new": res}
@@ -611,7 +648,6 @@ def configmap_present(name, namespace="default", data=None, source=None, templat
             ret["comment"] = "The configmap is going to be replaced"
             return ret
 
-        # TODO: improve checks  # pylint: disable=fixme
         log.info("Forcing the recreation of the service")
         ret["comment"] = "The configmap is already present. Forcing recreation"
         res = __salt__["kubernetes.replace_configmap"](
@@ -621,6 +657,7 @@ def configmap_present(name, namespace="default", data=None, source=None, templat
             source=source,
             template=template,
             saltenv=__env__,
+            context=context,
             **kwargs,
         )
 
@@ -669,7 +706,14 @@ def pod_absent(name, namespace="default", **kwargs):
 
 
 def pod_present(
-    name, namespace="default", metadata=None, spec=None, source="", template="", **kwargs
+    name,
+    namespace="default",
+    metadata=None,
+    spec=None,
+    source="",
+    template="",
+    context=None,
+    **kwargs,
 ):
     """
     Ensures that the named pod is present inside of the specified
@@ -695,6 +739,9 @@ def pod_present(
 
     template
         Template engine to be used to render the source file.
+
+    context
+        Variables to be passed into the template.
     """
     ret = {"name": name, "changes": {}, "result": False, "comment": ""}
 
@@ -722,6 +769,7 @@ def pod_present(
             source=source,
             template=template,
             saltenv=__env__,
+            context=context,
             **kwargs,
         )
         ret["changes"][f"{namespace}.{name}"] = {"old": {}, "new": res}

--- a/tests/unit/files/test-deployment.yaml
+++ b/tests/unit/files/test-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ context.name }}
+  labels:
+    app: {{ context.name }}
+spec:
+  replicas: {{ context.replicas }}
+  selector:
+    matchLabels:
+      app: {{ context.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ context.name }}
+    spec:
+      containers:
+      - name: {{ context.name }}
+        image: {{ context.image }}
+        ports:
+        - containerPort: {{ context.port | default(80) }}

--- a/tests/unit/files/test-service.yaml
+++ b/tests/unit/files/test-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ context.name }}
+spec:
+  selector:
+    app: {{ context.name }}
+  ports:
+    - protocol: TCP
+      port: {{ context.port }}
+      targetPort: {{ context.target_port | default(context.port) }}
+  type: {{ context.type | default('ClusterIP') }}

--- a/tests/unit/modules/test_kubernetesmod.py
+++ b/tests/unit/modules/test_kubernetesmod.py
@@ -74,7 +74,7 @@ def test_deployments():
     :return:
     """
     with mock_kubernetes_library() as mock_kubernetes_lib:
-        mock_kubernetes_lib.client.ExtensionsV1beta1Api.return_value = Mock(
+        mock_kubernetes_lib.client.ExtensionsV1Api.return_value = Mock(
             **{
                 "list_namespaced_deployment.return_value.to_dict.return_value": {
                     "items": [{"metadata": {"name": "mock_deployment_name"}}]
@@ -84,7 +84,7 @@ def test_deployments():
         assert kubernetes.deployments() == ["mock_deployment_name"]
         # py#int: disable=E1120
         assert (
-            kubernetes.kubernetes.client.ExtensionsV1beta1Api()
+            kubernetes.kubernetes.client.ExtensionsV1Api()
             .list_namespaced_deployment()
             .to_dict.called
         )
@@ -134,12 +134,12 @@ def test_delete_deployments():
             "saltext.kubernetes.modules.kubernetesmod.show_deployment", Mock(return_value=None)
         ):
             mock_kubernetes_lib.client.V1DeleteOptions = Mock(return_value="")
-            mock_kubernetes_lib.client.ExtensionsV1beta1Api.return_value = Mock(
+            mock_kubernetes_lib.client.ExtensionsV1Api.return_value = Mock(
                 **{"delete_namespaced_deployment.return_value.to_dict.return_value": {"code": ""}}
             )
             assert kubernetes.delete_deployment("test") == {"code": 200}
             assert (
-                kubernetes.kubernetes.client.ExtensionsV1beta1Api()
+                kubernetes.kubernetes.client.ExtensionsV1Api()
                 .delete_namespaced_deployment()
                 .to_dict.called
             )
@@ -151,12 +151,12 @@ def test_create_deployments():
     :return:
     """
     with mock_kubernetes_library() as mock_kubernetes_lib:
-        mock_kubernetes_lib.client.ExtensionsV1beta1Api.return_value = Mock(
+        mock_kubernetes_lib.client.ExtensionsV1Api.return_value = Mock(
             **{"create_namespaced_deployment.return_value.to_dict.return_value": {}}
         )
         assert kubernetes.create_deployment("test", "default", {}, {}, None, None, None) == {}
         assert (
-            kubernetes.kubernetes.client.ExtensionsV1beta1Api()
+            kubernetes.kubernetes.client.ExtensionsV1Api()
             .create_namespaced_deployment()
             .to_dict.called
         )

--- a/tests/unit/modules/test_kubernetesmod.py
+++ b/tests/unit/modules/test_kubernetesmod.py
@@ -74,7 +74,7 @@ def test_deployments():
     :return:
     """
     with mock_kubernetes_library() as mock_kubernetes_lib:
-        mock_kubernetes_lib.client.ExtensionsV1Api.return_value = Mock(
+        mock_kubernetes_lib.client.AppsV1Api.return_value = Mock(
             **{
                 "list_namespaced_deployment.return_value.to_dict.return_value": {
                     "items": [{"metadata": {"name": "mock_deployment_name"}}]
@@ -83,11 +83,7 @@ def test_deployments():
         )
         assert kubernetes.deployments() == ["mock_deployment_name"]
         # py#int: disable=E1120
-        assert (
-            kubernetes.kubernetes.client.ExtensionsV1Api()
-            .list_namespaced_deployment()
-            .to_dict.called
-        )
+        assert kubernetes.kubernetes.client.AppsV1Api().list_namespaced_deployment().to_dict.called
 
 
 def test_services():
@@ -134,12 +130,12 @@ def test_delete_deployments():
             "saltext.kubernetes.modules.kubernetesmod.show_deployment", Mock(return_value=None)
         ):
             mock_kubernetes_lib.client.V1DeleteOptions = Mock(return_value="")
-            mock_kubernetes_lib.client.ExtensionsV1Api.return_value = Mock(
+            mock_kubernetes_lib.client.AppsV1Api.return_value = Mock(
                 **{"delete_namespaced_deployment.return_value.to_dict.return_value": {"code": ""}}
             )
             assert kubernetes.delete_deployment("test") == {"code": 200}
             assert (
-                kubernetes.kubernetes.client.ExtensionsV1Api()
+                kubernetes.kubernetes.client.AppsV1Api()
                 .delete_namespaced_deployment()
                 .to_dict.called
             )
@@ -151,14 +147,12 @@ def test_create_deployments():
     :return:
     """
     with mock_kubernetes_library() as mock_kubernetes_lib:
-        mock_kubernetes_lib.client.ExtensionsV1Api.return_value = Mock(
+        mock_kubernetes_lib.client.AppsV1Api.return_value = Mock(
             **{"create_namespaced_deployment.return_value.to_dict.return_value": {}}
         )
         assert kubernetes.create_deployment("test", "default", {}, {}, None, None, None) == {}
         assert (
-            kubernetes.kubernetes.client.ExtensionsV1Api()
-            .create_namespaced_deployment()
-            .to_dict.called
+            kubernetes.kubernetes.client.AppsV1Api().create_namespaced_deployment().to_dict.called
         )
 
 


### PR DESCRIPTION
### What does this PR do?
This PR adds support for using context variables in templates for Kubernetes resources in the `kubernetes` state module and is dependent on PR #9. This enhancement allows for more dynamic and reusable template configurations when managing Kubernetes resources through Salt states.

### What issues does this PR fix or reference?
Fixes: #10  - Add support for context variables in Kubernetes templates. 
Dependencies: #9  - Update kubernetesmod to work with newer versions of of the kubernetes python client

### Previous Behavior
Previously, the `kubernetes` state module did not support passing context variables to templates when creating or updating Kubernetes resources, limiting the reusability and flexibility of template configurations.

### New Behavior
The module now supports passing context variables to templates for the following states:
- `kubernetes.deployment_present`
- `kubernetes.pod_present`
- `kubernetes.service_present`
- `kubernetes.configmap_present`
- `kubernetes.secret_present`

This allows for more dynamic and reusable template configurations, similar to how `file.managed` works in Salt.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [x] Docs - Updated function docstrings to include context parameter
- [x] Changelog - Added entry in changelog/2.feature.md
- [x] Tests written/updated - Added comprehensive tests for template context support

### Commits signed with GPG?
Yes
