### PR TITLE
Added support to manage statefulset resources

### DIFF
--- a/changelog/23.added.feature.md
+++ b/changelog/23.added.feature.md
@@ -1,0 +1,1 @@
+Added support to manage statefulset resources in kubernetes clusters.

--- a/src/saltext/kubernetes/modules/kubernetesmod.py
+++ b/src/saltext/kubernetes/modules/kubernetesmod.py
@@ -506,6 +506,39 @@ def configmaps(namespace="default", **kwargs):
         _cleanup(**cfg)
 
 
+def statefulsets(namespace="default", **kwargs):
+    """
+    .. versionadded:: 2.1.0
+
+    Return a list of kubernetes statefulsets defined in the namespace
+
+    namespace
+        The namespace to list statefulsets from. Defaults to ``default``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' kubernetes.statefulsets
+        salt '*' kubernetes.statefulsets namespace=default
+    """
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.AppsV1Api()
+        api_response = api_instance.list_namespaced_stateful_set(namespace)
+
+        return [
+            statefulset["metadata"]["name"]
+            for statefulset in ApiClient().sanitize_for_serialization(api_response).get("items", [])
+        ]
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return []  # Return empty list for nonexistent namespace
+        raise CommandExecutionError(exc) from exc
+    finally:
+        _cleanup(**cfg)
+
+
 def show_deployment(name, namespace="default", **kwargs):
     """
     Return the kubernetes deployment defined by name and namespace
@@ -696,6 +729,39 @@ def show_configmap(name, namespace="default", **kwargs):
     try:
         api_instance = kubernetes.client.CoreV1Api()
         api_response = api_instance.read_namespaced_config_map(name, namespace)
+
+        return ApiClient().sanitize_for_serialization(api_response)
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        raise CommandExecutionError(exc) from exc
+    finally:
+        _cleanup(**cfg)
+
+
+def show_statefulset(name, namespace="default", **kwargs):
+    """
+    .. versionadded:: 2.1.0
+
+    Return the kubernetes statefulset defined by name and namespace.
+
+    name
+        The name of the statefulset
+
+    namespace
+        The namespace to look for the statefulset. Defaults to ``default``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' kubernetes.show_statefulset my-statefulset default
+        salt '*' kubernetes.show_statefulset name=my-statefulset namespace=default
+    """
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.AppsV1Api()
+        api_response = api_instance.read_namespaced_stateful_set(name, namespace)
 
         return ApiClient().sanitize_for_serialization(api_response)
     except (ApiException, HTTPError) as exc:
@@ -1004,6 +1070,59 @@ def delete_configmap(name, namespace="default", wait=False, timeout=60, **kwargs
             return None
         else:
             raise CommandExecutionError(exc) from exc
+    finally:
+        _cleanup(**cfg)
+
+
+def delete_statefulset(name, namespace="default", wait=False, timeout=60, **kwargs):
+    """
+    .. versionadded:: 2.1.0
+
+    Deletes the kubernetes statefulset defined by name and namespace
+
+    name
+        The name of the statefulset
+
+    namespace
+        The namespace to delete the statefulset from. Defaults to ``default``.
+
+    wait
+        .. versionadded:: 2.0.0
+
+        Wait for statefulset deletion to complete (default: False)
+
+    timeout
+        .. versionadded:: 2.0.0
+
+        Timeout in seconds to wait for deletion (default: 60)
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' kubernetes.delete_statefulset my-statefulset default
+        salt '*' kubernetes.delete_statefulset name=my-statefulset namespace=default
+    """
+    cfg = _setup_conn(**kwargs)
+    body = kubernetes.client.V1DeleteOptions(orphan_dependents=True)
+
+    try:
+        api_instance = kubernetes.client.AppsV1Api()
+        api_response = api_instance.delete_namespaced_stateful_set(
+            name=name, namespace=namespace, body=body
+        )
+
+        if wait:
+            if not _wait_for_resource_status(
+                api_instance, "statefulset", name, namespace, "deleted", timeout
+            ):
+                raise CommandExecutionError(f"Timeout waiting for statefulset {name} to be deleted")
+
+        return ApiClient().sanitize_for_serialization(api_response)
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        raise CommandExecutionError(exc) from exc
     finally:
         _cleanup(**cfg)
 
@@ -1651,6 +1770,117 @@ def create_namespace(name, **kwargs):
         _cleanup(**cfg)
 
 
+def create_statefulset(
+    name,
+    namespace="default",
+    metadata=None,
+    spec=None,
+    source=None,
+    template=None,
+    saltenv=None,
+    template_context=None,
+    dry_run=False,
+    wait=False,
+    timeout=60,
+    **kwargs,
+):
+    """
+    .. versionadded:: 2.1.0
+
+    Creates a statefulset with the specified name, namespace, metadata, and spec.
+
+    name
+        The name of the statefulset
+
+    namespace
+        The namespace to create the statefulset in. Defaults to ``default``.
+
+    metadata
+        StatefulSet metadata dict
+
+    spec
+        StatefulSet spec dict following kubernetes API conventions
+
+    source
+        File path to statefulset definition
+
+    template
+        Template engine to use to render the source file
+
+    saltenv
+        Salt environment to pull the source file from
+
+        .. versionchanged:: 2.0.0
+            Defaults to the value of the :conf_minion:`saltenv` minion option or ``base``.
+
+    template_context
+        .. versionadded:: 2.0.0
+
+        Variables to make available in templated files
+
+    dry_run
+        .. versionadded:: 2.0.0
+
+        If True, only simulates the creation of the statefulset
+
+    wait
+        .. versionadded:: 2.0.0
+
+        Wait for statefulset to become ready (default: False)
+
+    timeout
+        .. versionadded:: 2.0.0
+
+        Timeout in seconds to wait for statefulset (default: 60)
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' kubernetes.create_statefulset name=my-statefulset namespace=default spec='{"replicas": 3}' wait=True
+    """
+    body = __create_object_body(
+        kind="StatefulSet",
+        obj_class=kubernetes.client.V1StatefulSet,
+        spec_creator=__dict_to_statefulset_spec,
+        name=name,
+        namespace=namespace,
+        metadata=metadata,
+        spec=spec,
+        source=source,
+        template=template,
+        saltenv=saltenv,
+        template_context=template_context,
+    )
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.AppsV1Api()
+        api_response = api_instance.create_namespaced_stateful_set(
+            namespace, body, dry_run="All" if dry_run else None
+        )
+
+        if wait:
+            if not _wait_for_resource_status(
+                api_instance, "statefulset", name, namespace, "ready", timeout
+            ):
+                raise CommandExecutionError(
+                    f"Timeout waiting for statefulset {name} to become ready"
+                )
+
+        return ApiClient().sanitize_for_serialization(api_response)
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException):
+            if exc.status == 404:
+                raise CommandExecutionError(f"StatefulSet {namespace}/{name} not found") from exc
+            if exc.status == 409:
+                raise CommandExecutionError(f"StatefulSet {name} already exists") from exc
+        raise CommandExecutionError(exc) from exc
+    finally:
+        _cleanup(**cfg)
+
+
 def replace_deployment(
     name,
     metadata,
@@ -2106,6 +2336,99 @@ def replace_configmap(
         _cleanup(**cfg)
 
 
+def replace_statefulset(
+    name,
+    namespace,
+    spec,
+    metadata=None,
+    source=None,
+    template=None,
+    saltenv=None,
+    template_context=None,
+    wait=False,
+    timeout=60,
+    **kwargs,
+):
+    """
+    .. versionadded:: 2.1.0
+
+    Replaces an existing statefulset with a new one defined by name and
+    namespace with the specified spec.
+
+    name
+        The name of the statefulset
+
+    namespace
+        The namespace of the statefulset
+
+    spec
+        A dictionary representing the spec of the statefulset
+
+    metadata
+        A dictionary representing the metadata of the statefulset
+
+    source
+        File path to statefulset definition
+
+    template
+        Template engine to use to render the source file
+
+    saltenv
+        Salt environment to pull the source file from
+
+    template_context
+        Variables to make available in templated files
+
+    wait
+        Wait for statefulset to become ready (default: False)
+
+    timeout
+        Timeout in seconds to wait for statefulset (default: 60)
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion1' kubernetes.replace_statefulset \
+            name=my-statefulset namespace=default spec='{"replicas": 3}'
+    """
+    body = __create_object_body(
+        kind="StatefulSet",
+        obj_class=kubernetes.client.V1StatefulSet,
+        spec_creator=__dict_to_statefulset_spec,
+        name=name,
+        namespace=namespace,
+        metadata=metadata,
+        spec=spec,
+        source=source,
+        template=template,
+        saltenv=saltenv,
+        template_context=template_context,
+    )
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.AppsV1Api()
+        api_response = api_instance.replace_namespaced_stateful_set(name, namespace, body)
+
+        if wait:
+            if not _wait_for_resource_status(
+                api_instance, "statefulset", name, namespace, "ready", timeout
+            ):
+                raise CommandExecutionError(
+                    f"Timeout waiting for statefulset {name} to become ready"
+                )
+
+        return ApiClient().sanitize_for_serialization(api_response)
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            raise CommandExecutionError(f"StatefulSet {namespace}/{name} not found") from exc
+        raise CommandExecutionError(exc) from exc
+    finally:
+        _cleanup(**cfg)
+
+
 def patch_service(
     name,
     namespace,
@@ -2478,6 +2801,99 @@ def patch_deployment(
             raise CommandExecutionError(f"Deployment {namespace}/{name} not found") from exc
         if isinstance(exc, ApiException) and exc.status == 409:
             raise CommandExecutionError(f"Conflict when patching deployment {name}") from exc
+        raise CommandExecutionError(exc) from exc
+    finally:
+        _cleanup(**cfg)
+
+
+def patch_statefulset(
+    name,
+    namespace,
+    patch=None,
+    source=None,
+    template=None,
+    saltenv=None,
+    template_context=None,
+    dry_run=False,
+    wait=False,
+    timeout=60,
+    **kwargs,
+):
+    """
+    .. versionadded:: 2.1.0
+
+    Patches an existing statefulset with the provided patch dictionary.
+
+    name
+        The name of the statefulset
+
+    namespace
+        The namespace of the statefulset
+
+    patch
+        A dictionary representing the patch to apply to the statefulset
+
+    source
+        File path to patch definition
+
+    template
+        Template engine to use to render the source file
+
+    saltenv
+        Salt environment to pull the source file from
+
+    template_context
+        Variables to make available in templated files
+
+    dry_run
+        If True, only simulates the patch without applying it (default: False)
+
+    wait
+        Wait for statefulset to become ready (default: False)
+
+    timeout
+        Timeout in seconds to wait for statefulset (default: 60)
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' kubernetes.patch_statefulset \
+            name=my-statefulset \
+            namespace=default \
+            patch='{"spec": {"replicas": 5}}'
+    """
+    if source:
+        rendered = __read_and_render_yaml_file(source, template, saltenv, template_context)
+        if not isinstance(rendered, dict):
+            raise CommandExecutionError("The source file did not render to a dictionary")
+        patch = rendered
+
+    if not isinstance(patch, dict):
+        raise CommandExecutionError("Patch must be a dictionary")
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.AppsV1Api()
+        api_response = api_instance.patch_namespaced_stateful_set(
+            name, namespace, patch, dry_run="All" if dry_run else None
+        )
+
+        if wait:
+            if not _wait_for_resource_status(
+                api_instance, "statefulset", name, namespace, "ready", timeout
+            ):
+                raise CommandExecutionError(
+                    f"Timeout waiting for statefulset {name} to become ready"
+                )
+
+        return ApiClient().sanitize_for_serialization(api_response)
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            raise CommandExecutionError(f"StatefulSet {namespace}/{name} not found") from exc
+        if isinstance(exc, ApiException) and exc.status == 409:
+            raise CommandExecutionError(f"Conflict when patching statefulset {name}") from exc
         raise CommandExecutionError(exc) from exc
     finally:
         _cleanup(**cfg)
@@ -2884,6 +3300,79 @@ def __dict_to_service_spec(spec):
     return spec_obj
 
 
+def __dict_to_statefulset_spec(spec):
+    """
+    .. versionadded:: 2.1.0
+
+    Converts a dictionary into kubernetes V1StatefulSetSpec instance.
+    """
+    if not isinstance(spec, dict):
+        raise CommandExecutionError(
+            f"StatefulSet spec must be a dictionary, not {type(spec).__name__}"
+        )
+
+    processed_spec = spec.copy()
+
+    # Validate required fields (accept both camelCase and snake_case input)
+    if "serviceName" not in processed_spec and "service_name" not in processed_spec:
+        raise CommandExecutionError("StatefulSet spec must include 'serviceName'")
+
+    # Validate required template field
+    if "template" not in processed_spec:
+        raise CommandExecutionError("StatefulSet spec must include template with pod specification")
+
+    template = processed_spec["template"]
+    if not isinstance(template, dict):
+        raise CommandExecutionError(f"Template must be a dictionary, not {type(template).__name__}")
+
+    template_metadata = template.get("metadata", {})
+    template_spec = template.get("spec", {})
+
+    # Validate template has pod spec
+    if not template_spec:
+        raise CommandExecutionError("Template must include pod specification")
+
+    # Create pod spec
+    try:
+        pod_spec = __dict_to_pod_spec(template_spec)
+    except (CommandExecutionError, ValueError) as exc:
+        raise CommandExecutionError(f"Invalid pod spec in statefulset template: {exc}") from exc
+
+    # Create pod template
+    pod_template = kubernetes.client.V1PodTemplateSpec(
+        metadata=kubernetes.client.V1ObjectMeta(**template_metadata), spec=pod_spec
+    )
+    processed_spec["template"] = pod_template
+
+    # Handle selector - optional for StatefulSet but validate if provided
+    if "selector" in processed_spec:
+        selector = processed_spec["selector"]
+        if not isinstance(selector, dict):
+            raise CommandExecutionError(
+                f"Selector must be a dictionary, not {type(selector).__name__}"
+            )
+        if "matchLabels" in selector:
+            processed_spec["selector"] = {"match_labels": selector["matchLabels"]}
+        processed_spec["selector"] = kubernetes.client.V1LabelSelector(**processed_spec["selector"])
+
+    # Handle replicas conversion
+    if "replicas" in processed_spec:
+        try:
+            processed_spec["replicas"] = int(processed_spec["replicas"])
+        except (TypeError, ValueError) as exc:
+            raise CommandExecutionError(f"replicas must be an integer: {exc}") from exc
+
+    # Convert serviceName (camelCase from YAML/user input) to service_name (Python client)
+    if "serviceName" in processed_spec:
+        processed_spec["service_name"] = processed_spec.pop("serviceName")
+
+    # Create final spec
+    try:
+        return kubernetes.client.V1StatefulSetSpec(**processed_spec)
+    except (TypeError, ValueError) as exc:
+        raise CommandExecutionError(f"Invalid statefulset spec: {exc}") from exc
+
+
 def __enforce_only_strings_dict(dictionary):
     """
     Returns a dictionary that has string keys and values.
@@ -2945,6 +3434,8 @@ def _wait_for_resource_status(
                         api_instance.read_namespaced_secret(name, namespace)
                     elif resource_type == "configmap":
                         api_instance.read_namespaced_config_map(name, namespace)
+                    elif resource_type == "statefulset":
+                        api_instance.read_namespaced_stateful_set(name, namespace)
                 except ApiException as e:
                     if e.status == 404:
                         # Resource is gone, deletion successful
@@ -2955,8 +3446,14 @@ def _wait_for_resource_status(
             return False
 
         # For creation/ready status watching
+        # statefulset maps to list_namespaced_stateful_set (compound word in k8s client)
+        list_method_name = (
+            "list_namespaced_stateful_set"
+            if resource_type == "statefulset"
+            else f"list_namespaced_{resource_type}"
+        )
         for event in w.stream(
-            func=getattr(api_instance, f"list_namespaced_{resource_type}"),
+            func=getattr(api_instance, list_method_name),
             namespace=namespace,
             field_selector=f"metadata.name={name}",
             timeout_seconds=timeout,

--- a/src/saltext/kubernetes/states/kubernetes.py
+++ b/src/saltext/kubernetes/states/kubernetes.py
@@ -388,6 +388,249 @@ def deployment_present(
     return ret
 
 
+def statefulset_absent(name, namespace="default", wait=False, timeout=60, **kwargs):
+    """
+    .. versionadded:: 2.1.0
+
+    Ensures that the named statefulset is absent from the given namespace.
+
+    name
+        The name of the statefulset
+
+    namespace
+        The name of the namespace
+
+    wait
+        If set to True, the function will wait until the statefulset is deleted.
+
+    timeout
+        The time in seconds to wait for the statefulset to be deleted.
+
+    Example:
+
+    .. code-block:: yaml
+
+        my-statefulset:
+          kubernetes.statefulset_absent:
+            - namespace: default
+    """
+
+    ret = {"name": name, "changes": {}, "result": False, "comment": ""}
+
+    try:
+        statefulset = __salt__["kubernetes.show_statefulset"](name, namespace, **kwargs)
+
+        if statefulset is None:
+            ret["result"] = True
+            ret["comment"] = "The statefulset does not exist"
+            return ret
+
+        if __opts__["test"]:
+            ret["result"] = None
+            ret["comment"] = "The statefulset is going to be deleted"
+            ret["changes"] = {
+                "old": "present",
+                "new": "absent",
+            }
+            return ret
+
+        __salt__["kubernetes.delete_statefulset"](
+            name, namespace, wait=wait, timeout=timeout, **kwargs
+        )
+
+        ret["result"] = True
+        ret["changes"] = {"old": "present", "new": "absent"}
+        ret["comment"] = f"StatefulSet {name} deleted"
+
+    except CommandExecutionError as err:
+        log.error(str(err), exc_info_on_loglevel=logging.DEBUG)
+        ret["result"] = False
+        ret["comment"] = str(err)
+        ret["changes"] = {}
+
+    return ret
+
+
+def statefulset_present(
+    name,
+    namespace="default",
+    metadata=None,
+    spec=None,
+    source="",
+    template="",
+    template_context=None,
+    wait=False,
+    timeout=60,
+    **kwargs,
+):
+    """
+    .. versionadded:: 2.1.0
+
+    Ensures that the named statefulset is present inside of the specified
+    namespace with the given metadata and spec.
+    If the statefulset exists, it will be patched with the desired state.
+
+    name
+        The name of the statefulset.
+
+    namespace
+        The namespace holding the statefulset. The 'default' one is going to be
+        used unless a different one is specified.
+
+    metadata
+        The metadata of the statefulset object.
+
+    spec
+        The spec of the statefulset object.
+
+    source
+        A file containing the definition of the statefulset (metadata and
+        spec) in the official kubernetes format.
+
+    template
+        Template engine to be used to render the source file.
+
+    template_context
+        Variables to be passed into the template.
+
+    wait
+        If set to True, the function will wait until the statefulset is ready.
+
+    timeout
+        The time in seconds to wait for the statefulset to be ready.
+
+    Example:
+
+    .. code-block:: yaml
+
+        my-statefulset:
+          kubernetes.statefulset_present:
+            - namespace: default
+            - metadata:
+                app: myapp
+            - spec:
+                serviceName: my-service
+                replicas: 3
+                selector:
+                  matchLabels:
+                    app: myapp
+                template:
+                  metadata:
+                    labels:
+                      app: myapp
+                  spec:
+                    containers:
+                    - name: myapp
+                      image: myapp:latest
+                      ports:
+                      - containerPort: 8080
+    """
+    ret = {"name": name, "changes": {}, "result": False, "comment": ""}
+
+    if (metadata or spec) and source:
+        return _error(ret, "'source' cannot be used in combination with 'metadata' or 'spec'")
+
+    if metadata is None:
+        metadata = {}
+
+    if spec is None:
+        spec = {}
+
+    try:
+        statefulset = __salt__["kubernetes.show_statefulset"](name, namespace, **kwargs)
+
+        if statefulset is None:
+            try:
+                res = __salt__["kubernetes.create_statefulset"](
+                    name=name,
+                    namespace=namespace,
+                    metadata=metadata,
+                    spec=spec,
+                    source=source,
+                    template=template,
+                    saltenv=__env__,
+                    template_context=template_context,
+                    dry_run=bool(__opts__["test"]),
+                    wait=wait if not __opts__["test"] else False,
+                    timeout=timeout,
+                    **kwargs,
+                )
+            except CommandExecutionError as err:
+                if not __opts__["test"]:
+                    raise
+                ret["result"] = None
+                ret["comment"] = (
+                    "The statefulset is going to be created. "
+                    f"Dry run failed, possibly due to dependencies not created yet: {err}"
+                )
+                return ret
+
+            ret["changes"] = {"old": {}, "new": res}
+            if __opts__["test"]:
+                ret["result"] = None
+                ret["comment"] = "The statefulset is going to be created"
+            else:
+                ret["result"] = True
+                ret["comment"] = "StatefulSet created"
+            return ret
+
+        # StatefulSet exists — build the patch object
+        if source:
+            patch_kwargs = {
+                "source": source,
+                "template": template,
+                "template_context": template_context,
+            }
+        else:
+            patch_obj = {}
+            if metadata:
+                patch_obj["metadata"] = metadata
+            if spec:
+                patch_obj["spec"] = spec
+            patch_kwargs = {"patch": patch_obj}
+
+        try:
+            res = __salt__["kubernetes.patch_statefulset"](
+                name,
+                namespace,
+                dry_run=bool(__opts__["test"]),
+                wait=wait,
+                timeout=timeout,
+                **patch_kwargs,
+                **kwargs,
+            )
+        except CommandExecutionError as err:
+            if not __opts__["test"]:
+                raise
+            ret["result"] = None
+            ret["comment"] = (
+                "The statefulset is going to be updated. "
+                f"Dry run failed, possibly due to dependencies not created yet: {err}"
+            )
+            return ret
+
+        if res == statefulset:
+            ret["result"] = True
+            ret["comment"] = "The statefulset is already in the desired state"
+            return ret
+
+        ret["changes"] = _changes(statefulset, res)
+        if __opts__["test"]:
+            ret["result"] = None
+            ret["comment"] = "The statefulset is going to be updated"
+        else:
+            ret["result"] = True
+            ret["comment"] = "StatefulSet updated"
+
+    except CommandExecutionError as err:
+        log.error(str(err), exc_info_on_loglevel=logging.DEBUG)
+        ret["result"] = False
+        ret["comment"] = str(err)
+        ret["changes"] = {}
+
+    return ret
+
+
 def service_present(
     name,
     namespace="default",

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -242,6 +242,52 @@ def deployment(kubernetes_exe, deployment_spec, request):
         assert kubernetes_exe.show_deployment(name=name, namespace=namespace) is None
 
 
+@pytest.fixture
+def statefulset_spec():
+    """
+    Fixture providing a basic statefulset spec
+    """
+    return {
+        "serviceName": "statefulset-service",
+        "replicas": 1,
+        "selector": {"matchLabels": {"app": "nginx"}},
+        "template": {
+            "metadata": {"labels": {"app": "nginx"}},
+            "spec": {"containers": [{"name": "nginx", "image": "nginx:latest"}]},
+        },
+    }
+
+
+@pytest.fixture(params=[True])
+def statefulset(kubernetes_exe, statefulset_spec, request):
+    """
+    Fixture to create a test statefulset.
+
+    If request.param is True, statefulset is created before the test.
+    If request.param is False, statefulset is not created.
+    """
+    name = random_string("statefulset-", uppercase=False)
+    namespace = "default"
+
+    if request.param:
+        res = kubernetes_exe.create_statefulset(
+            name=name,
+            namespace=namespace,
+            metadata={},
+            spec=statefulset_spec,
+            wait=True,
+        )
+        assert isinstance(res, dict)
+        assert res["metadata"]["name"] == name
+        assert res["spec"]["replicas"] == statefulset_spec["replicas"]
+
+    try:
+        yield {"name": name, "namespace": namespace, "spec": statefulset_spec}
+    finally:
+        kubernetes_exe.delete_statefulset(name=name, namespace=namespace, wait=True)
+        assert kubernetes_exe.show_statefulset(name=name, namespace=namespace) is None
+
+
 @pytest.fixture(params=[True])
 def secret(kubernetes_exe, secret_data, request):
     """

--- a/tests/functional/modules/test_kubernetesmod.py
+++ b/tests/functional/modules/test_kubernetesmod.py
@@ -763,6 +763,208 @@ def test_list_deployments_in_nonexistent_namespace(kubernetes, namespace):
     assert res == []
 
 
+def test_statefulsets(kubernetes, statefulset):
+    """
+    Test that the statefulsets function returns a list of statefulsets in the specified namespace
+    """
+    res = kubernetes.statefulsets(statefulset["namespace"])
+    assert isinstance(res, list)
+    assert statefulset["name"] in res
+
+
+@pytest.mark.parametrize("statefulset", [False], indirect=True)
+def test_create_statefulset(kubernetes, statefulset):
+    """
+    Test creating a statefulset returns expected result
+    """
+    res = kubernetes.create_statefulset(
+        name=statefulset["name"],
+        namespace=statefulset["namespace"],
+        metadata={},
+        spec=statefulset["spec"],
+        source=None,
+        template=None,
+        saltenv="base",
+        wait=True,
+    )
+    assert isinstance(res, dict)
+    assert res["metadata"]["name"] == statefulset["name"]
+    assert res["metadata"]["namespace"] == statefulset["namespace"]
+
+
+def test_create_existing_statefulset(kubernetes, statefulset):
+    """
+    Test creating a statefulset that already exists raises appropriate error
+    """
+    with pytest.raises(CommandExecutionError, match=".*already exists.*"):
+        kubernetes.create_statefulset(
+            name=statefulset["name"],
+            namespace=statefulset["namespace"],
+            metadata={},
+            spec=statefulset["spec"],
+            source=None,
+            template=None,
+            saltenv="base",
+            wait=True,
+        )
+
+
+def test_show_statefulset(kubernetes, statefulset):
+    """
+    Test showing a statefulset returns expected result
+    """
+    res = kubernetes.show_statefulset(statefulset["name"], statefulset["namespace"])
+    assert isinstance(res, dict)
+    assert res["metadata"]["name"] == statefulset["name"]
+    assert res["metadata"]["namespace"] == statefulset["namespace"]
+    assert res["spec"]["replicas"] == statefulset["spec"]["replicas"]
+    assert res["spec"]["selector"] == statefulset["spec"]["selector"]
+
+
+@pytest.mark.parametrize("statefulset", [False], indirect=True)
+def test_show_nonexistent_statefulset(kubernetes, statefulset):
+    """
+    Test showing a statefulset that doesn't exist returns None
+    """
+    res = kubernetes.show_statefulset(statefulset["name"], statefulset["namespace"])
+    assert res is None
+
+
+def test_replace_statefulset(kubernetes, statefulset):
+    """
+    Test replacing a statefulset with new spec
+    """
+    new_spec = statefulset["spec"].copy()
+    new_spec["replicas"] = 2
+
+    res = kubernetes.replace_statefulset(
+        name=statefulset["name"],
+        namespace=statefulset["namespace"],
+        metadata={},
+        spec=new_spec,
+        source=None,
+        template=None,
+        saltenv="base",
+        wait=True,
+    )
+    assert isinstance(res, dict)
+    assert res["spec"]["replicas"] == 2
+
+
+@pytest.mark.parametrize("statefulset", [False], indirect=True)
+def test_replace_nonexistent_statefulset(kubernetes, statefulset):
+    """
+    Test replacing a statefulset that doesn't exist raises appropriate error
+    """
+    new_spec = statefulset["spec"].copy()
+    new_spec["replicas"] = 2
+
+    with pytest.raises(CommandExecutionError, match=".*not found.*"):
+        kubernetes.replace_statefulset(
+            name=statefulset["name"],
+            namespace=statefulset["namespace"],
+            metadata={},
+            spec=new_spec,
+            source=None,
+            template=None,
+            saltenv="base",
+            wait=True,
+        )
+
+
+def test_patch_statefulset(kubernetes, statefulset):
+    """
+    Test patching a statefulset to change the number of replicas.
+    """
+    patch = {
+        "spec": {
+            "replicas": 2,
+        }
+    }
+    res = kubernetes.patch_statefulset(
+        statefulset["name"],
+        statefulset["namespace"],
+        patch,
+        wait=True,
+        timeout=120,
+    )
+    assert isinstance(res, dict)
+    assert res["spec"]["replicas"] == 2
+
+
+@pytest.mark.parametrize("statefulset", [False], indirect=True)
+def test_patch_nonexistent_statefulset(kubernetes, statefulset):
+    """
+    Test patching a statefulset that doesn't exist raises appropriate error
+    """
+    patch = {"spec": {"replicas": 2}}
+    with pytest.raises(CommandExecutionError, match=".*not found.*"):
+        kubernetes.patch_statefulset(
+            statefulset["name"],
+            statefulset["namespace"],
+            patch,
+            wait=True,
+            timeout=120,
+        )
+
+
+def test_patch_preserves_spec_replace_is_full_statefulset(kubernetes, statefulset):
+    """
+    Test that patch merges into spec while replace overwrites it entirely.
+    """
+    kubernetes.patch_statefulset(
+        statefulset["name"],
+        statefulset["namespace"],
+        {"spec": {"template": {"metadata": {"annotations": {"note": "patched"}}}}},
+        wait=True,
+    )
+    res = kubernetes.show_statefulset(statefulset["name"], statefulset["namespace"])
+    assert res["spec"]["replicas"] == 1
+    assert res["spec"]["template"]["metadata"]["annotations"]["note"] == "patched"
+
+    kubernetes.replace_statefulset(
+        name=statefulset["name"],
+        namespace=statefulset["namespace"],
+        metadata={},
+        spec=statefulset["spec"],
+        source=None,
+        template=None,
+        saltenv="base",
+        wait=True,
+    )
+    res = kubernetes.show_statefulset(statefulset["name"], statefulset["namespace"])
+    assert not res["spec"]["template"]["metadata"].get("annotations", {})
+
+
+def test_delete_existing_statefulset(kubernetes, statefulset):
+    """
+    Test deleting a statefulset that exists returns expected result
+    """
+    res = kubernetes.delete_statefulset(statefulset["name"], statefulset["namespace"], wait=True)
+    assert isinstance(res, dict)
+
+    deleted_statefulset = kubernetes.show_statefulset(statefulset["name"], statefulset["namespace"])
+    assert deleted_statefulset is None
+
+
+@pytest.mark.parametrize("statefulset", [False], indirect=True)
+def test_delete_nonexistent_statefulset(kubernetes, statefulset):
+    """
+    Test deleting a statefulset that doesn't exist returns None
+    """
+    res = kubernetes.delete_statefulset(statefulset["name"], statefulset["namespace"])
+    assert res is None
+
+
+@pytest.mark.parametrize("namespace", [False], indirect=True)
+def test_list_statefulsets_in_nonexistent_namespace(kubernetes, namespace):
+    """
+    Test listing statefulsets in a namespace that doesn't exist returns empty list
+    """
+    res = kubernetes.statefulsets(namespace)
+    assert res == []
+
+
 @pytest.fixture
 def service_spec(request):
     """

--- a/tests/functional/states/test_kubernetes.py
+++ b/tests/functional/states/test_kubernetes.py
@@ -525,6 +525,220 @@ def test_deployment_absent_idempotency(kubernetes, deployment, testmode):
 
 
 @pytest.fixture
+def statefulset_template(state_tree):
+    sls = "k8s/statefulset-template"
+    contents = dedent("""
+        apiVersion: apps/v1
+        kind: StatefulSet
+        metadata:
+          name: {{ name }}
+          namespace: {{ namespace }}
+          labels: {{ labels | json }}
+        spec:
+          serviceName: {{ service_name }}
+          replicas: {{ replicas }}
+          selector:
+            matchLabels:
+              app: {{ app_label }}
+          template:
+            metadata:
+              labels: {{ labels | json }}
+            spec:
+              containers:
+              - name: {{ name }}
+                image: {{ image }}
+                ports:
+                - containerPort: 80
+        """).strip()
+
+    with pytest.helpers.temp_file(f"{sls}.yml.jinja", contents, state_tree):
+        yield f"salt://{sls}.yml.jinja"
+
+
+@pytest.mark.parametrize("statefulset", [False], indirect=True)
+def test_statefulset_present(kubernetes, statefulset, testmode, kubernetes_exe):
+    """
+    Test kubernetes.statefulset_present creates a statefulset
+    """
+    ret = kubernetes.statefulset_present(
+        name=statefulset["name"],
+        namespace=statefulset["namespace"],
+        spec=statefulset["spec"],
+        wait=True,
+        test=testmode,
+    )
+
+    assert ret.result in (None, True)
+    assert (ret.result is None) is testmode
+    if not testmode:
+        assert ret.changes["new"]["spec"]["replicas"] == statefulset["spec"]["replicas"]
+        statefulset_state = kubernetes_exe.show_statefulset(
+            name=statefulset["name"], namespace=statefulset["namespace"]
+        )
+        assert statefulset_state["metadata"]["name"] == statefulset["name"]
+        assert statefulset_state["spec"]["replicas"] == statefulset["spec"]["replicas"]
+    else:
+        assert ret.changes["new"]["spec"]["replicas"] == statefulset["spec"]["replicas"]
+        statefulset_state = kubernetes_exe.show_statefulset(
+            name=statefulset["name"], namespace=statefulset["namespace"]
+        )
+        assert statefulset_state is None
+
+
+def test_statefulset_present_idempotency(kubernetes, statefulset, testmode):
+    """
+    Test kubernetes.statefulset_present is idempotent
+    """
+    ret = kubernetes.statefulset_present(
+        name=statefulset["name"],
+        namespace=statefulset["namespace"],
+        spec=statefulset["spec"],
+        wait=True,
+        test=testmode,
+    )
+    assert ret.result is True
+    assert "The statefulset is already in the desired state" in ret.comment
+    assert not ret.changes
+
+
+def test_statefulset_present_patch(kubernetes, statefulset, kubernetes_exe, testmode):
+    """
+    Test kubernetes.statefulset_present patches a statefulset
+    """
+    statefulset["spec"]["replicas"] = 2
+
+    ret = kubernetes.statefulset_present(
+        name=statefulset["name"],
+        namespace=statefulset["namespace"],
+        spec=statefulset["spec"],
+        wait=True,
+        test=testmode,
+    )
+    assert ret.result in (None, True)
+    assert (ret.result is None) is testmode
+    assert ret.changes["new"]["spec"]["replicas"] == 2
+
+    statefulset_state = kubernetes_exe.show_statefulset(
+        name=statefulset["name"], namespace=statefulset["namespace"]
+    )
+    assert statefulset_state["metadata"]["name"] == statefulset["name"]
+    assert (statefulset_state["spec"]["replicas"] == 2) is not testmode
+
+
+def test_statefulset_present_patch_source(
+    kubernetes, statefulset, statefulset_template, kubernetes_exe
+):
+    """
+    Test kubernetes.statefulset_present patches a statefulset using source/template
+    """
+    template_context = {
+        "name": statefulset["name"],
+        "namespace": statefulset["namespace"],
+        "service_name": statefulset["spec"]["serviceName"],
+        "replicas": statefulset["spec"]["replicas"],
+        "app_label": "nginx",
+        "image": "nginx:1.27",
+        "labels": {"app": "nginx"},
+    }
+
+    ret = kubernetes.statefulset_present(
+        name=statefulset["name"],
+        namespace=statefulset["namespace"],
+        source=statefulset_template,
+        template="jinja",
+        template_context=template_context,
+        wait=True,
+    )
+    assert ret.result is True
+
+    statefulset_state = kubernetes_exe.show_statefulset(
+        name=statefulset["name"], namespace=statefulset["namespace"]
+    )
+    assert statefulset_state["metadata"]["name"] == statefulset["name"]
+    assert statefulset_state["spec"]["template"]["spec"]["containers"][0]["image"] == "nginx:1.27"
+
+
+@pytest.mark.parametrize("statefulset", [False], indirect=True)
+def test_statefulset_present_template_context(
+    kubernetes, statefulset, statefulset_template, kubernetes_exe
+):
+    """
+    Test kubernetes.statefulset_present with template_context
+    """
+    template_context = {
+        "name": statefulset["name"],
+        "namespace": statefulset["namespace"],
+        "service_name": statefulset["spec"]["serviceName"],
+        "replicas": statefulset["spec"]["replicas"],
+        "app_label": "test",
+        "image": "nginx:latest",
+        "labels": {"app": "test"},
+    }
+
+    ret = kubernetes.statefulset_present(
+        name=statefulset["name"],
+        namespace=statefulset["namespace"],
+        source=statefulset_template,
+        template="jinja",
+        template_context=template_context,
+        wait=True,
+    )
+    assert ret.result is True
+
+    statefulset_state = kubernetes_exe.show_statefulset(
+        name=statefulset["name"], namespace=statefulset["namespace"]
+    )
+    assert statefulset_state["metadata"]["name"] == statefulset["name"]
+    assert statefulset_state["spec"]["replicas"] == statefulset["spec"]["replicas"]
+    assert statefulset_state["metadata"]["labels"]["app"] == "test"
+    assert statefulset_state["spec"]["selector"]["matchLabels"]["app"] == "test"
+    assert statefulset_state["spec"]["template"]["spec"]["containers"][0]["image"] == "nginx:latest"
+
+
+def test_statefulset_absent(kubernetes, statefulset, testmode, kubernetes_exe):
+    """
+    Test kubernetes.statefulset_absent deletes a statefulset
+    """
+    ret = kubernetes.statefulset_absent(
+        name=statefulset["name"],
+        namespace=statefulset["namespace"],
+        wait=True,
+        test=testmode,
+    )
+
+    assert ret.result in (None, True)
+    assert (ret.result is None) is testmode
+
+    if not testmode:
+        assert ret.changes["new"] == "absent"
+        statefulset_state = kubernetes_exe.show_statefulset(
+            name=statefulset["name"], namespace=statefulset["namespace"]
+        )
+        assert statefulset_state is None
+    else:
+        assert ret.changes["new"] == "absent"
+        assert "The statefulset is going to be deleted" in ret.comment
+        statefulset_state = kubernetes_exe.show_statefulset(
+            name=statefulset["name"], namespace=statefulset["namespace"]
+        )
+        assert statefulset_state is not None
+        assert statefulset_state["metadata"]["name"] == statefulset["name"]
+
+
+@pytest.mark.parametrize("statefulset", [False], indirect=True)
+def test_statefulset_absent_idempotency(kubernetes, statefulset, testmode):
+    """
+    Test kubernetes.statefulset_absent is idempotent
+    """
+    ret = kubernetes.statefulset_absent(
+        name=statefulset["name"], namespace=statefulset["namespace"], wait=True, test=testmode
+    )
+    assert ret.result is True
+    assert "does not exist" in ret.comment
+    assert not ret.changes
+
+
+@pytest.fixture
 def secret_data():
     return {"key": "value"}, "Opaque"
 

--- a/tests/unit/modules/test_kubernetesmod.py
+++ b/tests/unit/modules/test_kubernetesmod.py
@@ -361,12 +361,59 @@ def test_deployments_handles_empty_response(mock_api):
         assert result == []
 
 
+def test_statefulsets_handles_api_exception(mock_api):
+    """
+    Test that statefulsets() handles ApiException properly
+    """
+    mock_api.client.AppsV1Api().list_namespaced_stateful_set.side_effect = ApiException(
+        status=500, reason="Internal Server Error"
+    )
+
+    with pytest.raises(CommandExecutionError):
+        kubernetes.statefulsets()
+
+
+def test_statefulsets_handles_404_gracefully(mock_api):
+    """
+    Test that statefulsets() returns empty list for 404 (namespace not found)
+    """
+    mock_api.client.AppsV1Api().list_namespaced_stateful_set.side_effect = ApiException(
+        status=404, reason="Not Found"
+    )
+
+    result = kubernetes.statefulsets("nonexistent-namespace")
+    assert result == []
+
+
+def test_statefulsets_handles_empty_response(mock_api):
+    """
+    Test that statefulsets() handles response with no items gracefully
+    """
+    with patch("saltext.kubernetes.modules.kubernetesmod.ApiClient") as mock_api_client_class:
+        mock_api_client_instance = Mock()
+        mock_api_client_instance.sanitize_for_serialization.return_value = {}
+        mock_api_client_class.return_value = mock_api_client_instance
+
+        mock_api.client.AppsV1Api().list_namespaced_stateful_set.return_value = Mock()
+
+        result = kubernetes.statefulsets()
+        assert result == []
+
+
 def test_patch_deployment_validates_patch_parameter():
     """
     Test patch_deployment raises error when patch is not a dictionary
     """
     with pytest.raises(CommandExecutionError, match="Patch must be a dictionary"):
         kubernetes.patch_deployment("test", "default", patch="not-a-dict")
+
+
+def test_patch_statefulset_validates_patch_parameter():
+    """
+    Test patch_statefulset raises error when patch is not a dictionary
+    """
+    with pytest.raises(CommandExecutionError, match="Patch must be a dictionary"):
+        kubernetes.patch_statefulset("test", "default", patch="not-a-dict")
 
 
 def test_patch_deployment_handles_missing_deployment(mock_api):
@@ -382,6 +429,18 @@ def test_patch_deployment_handles_missing_deployment(mock_api):
         kubernetes.patch_deployment("nonexistent", "default", patch={"spec": {"replicas": 3}})
 
 
+def test_patch_statefulset_handles_missing_statefulset(mock_api):
+    """
+    Test patch_statefulset handles case where statefulset doesn't exist
+    """
+    mock_api.client.AppsV1Api().patch_namespaced_stateful_set.side_effect = ApiException(
+        status=404, reason="Not Found"
+    )
+
+    with pytest.raises(CommandExecutionError):
+        kubernetes.patch_statefulset("nonexistent", "default", patch={"spec": {"replicas": 3}})
+
+
 def test_delete_deployment_handles_already_deleted(mock_api):
     """
     Test delete_deployment returns None when deployment is already deleted (404)
@@ -391,6 +450,18 @@ def test_delete_deployment_handles_already_deleted(mock_api):
         status=404, reason="Not Found"
     )
     result = kubernetes.delete_deployment("already-deleted", "default")
+    assert result is None
+
+
+def test_delete_statefulset_handles_already_deleted(mock_api):
+    """
+    Test delete_statefulset returns None when statefulset is already deleted (404)
+    """
+    mock_api.client.V1DeleteOptions.return_value = MagicMock()
+    mock_api.client.AppsV1Api.return_value.delete_namespaced_stateful_set.side_effect = (
+        ApiException(status=404, reason="Not Found")
+    )
+    result = kubernetes.delete_statefulset("already-deleted", "default")
     assert result is None
 
 
@@ -431,6 +502,47 @@ def test_patch_deployment_handles_invalid_yaml():
             with patch.dict(kubernetes.__opts__, {"saltenv": "base"}):
                 with pytest.raises(CommandExecutionError, match="did not render to a dictionary"):
                     kubernetes.patch_deployment(
+                        "test", "default", patch=None, source="salt://invalid.yml"
+                    )
+    finally:
+        os.unlink(tmpfile)
+
+
+def test_patch_statefulset_handles_source_rendering_error():
+    """
+    Test patch_statefulset handles template rendering errors gracefully
+    """
+    with patch.dict(
+        kubernetes.__salt__,
+        {
+            "cp.cache_file": MagicMock(return_value=None),
+        },
+    ):
+        with patch.dict(kubernetes.__opts__, {"saltenv": "base"}):
+            with pytest.raises(CommandExecutionError, match="Source file.*not found"):
+                kubernetes.patch_statefulset(
+                    "test", "default", patch=None, source="salt://bad-template.yml"
+                )
+
+
+def test_patch_statefulset_handles_invalid_yaml():
+    """
+    Test patch_statefulset raises error when source file does not render to a dictionary
+    """
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+        f.write("- item1\n- item2\n")
+        tmpfile = f.name
+
+    try:
+        with patch.dict(
+            kubernetes.__salt__,
+            {
+                "cp.cache_file": MagicMock(return_value=tmpfile),
+            },
+        ):
+            with patch.dict(kubernetes.__opts__, {"saltenv": "base"}):
+                with pytest.raises(CommandExecutionError, match="did not render to a dictionary"):
+                    kubernetes.patch_statefulset(
                         "test", "default", patch=None, source="salt://invalid.yml"
                     )
     finally:
@@ -578,6 +690,20 @@ def test_create_service_handles_conflict(mock_api):
             kubernetes.create_service("test", "default", {}, {}, None, None, None)
 
 
+def test_create_statefulset_handles_conflict(mock_api):
+    """
+    Test create_statefulset raises for 409 conflict (already exists)
+    """
+    with patch(
+        "saltext.kubernetes.modules.kubernetesmod.__create_object_body", return_value=MagicMock()
+    ):
+        mock_api.client.AppsV1Api().create_namespaced_stateful_set.side_effect = ApiException(
+            status=409, reason="AlreadyExists"
+        )
+        with pytest.raises(CommandExecutionError, match="already exists"):
+            kubernetes.create_statefulset("test", "default", {}, {}, None, None, None)
+
+
 def test_patch_deployment_handles_conflict(mock_api):
     """
     Test patch_deployment raises for 409 conflict (concurrent modification)
@@ -598,6 +724,66 @@ def test_patch_configmap_handles_conflict(mock_api):
     )
     with pytest.raises(CommandExecutionError, match="Conflict when patching"):
         kubernetes.patch_configmap("test", "default", patch={"data": {"key": "val"}})
+
+
+def test_patch_statefulset_handles_conflict(mock_api):
+    """
+    Test patch_statefulset raises for 409 conflict (concurrent modification)
+    """
+    mock_api.client.AppsV1Api().patch_namespaced_stateful_set.side_effect = ApiException(
+        status=409, reason="Conflict"
+    )
+    with pytest.raises(CommandExecutionError, match="Conflict when patching"):
+        kubernetes.patch_statefulset("test", "default", patch={"spec": {"replicas": 3}})
+
+
+@pytest.mark.parametrize(
+    "invalid_spec,expected_error",
+    [
+        ({"template": {}}, "serviceName"),
+        ({"serviceName": "svc"}, "template"),
+        ({"serviceName": "svc", "template": "not-a-dict"}, "Template must be a dictionary"),
+        (
+            {
+                "serviceName": "svc",
+                "template": {
+                    "metadata": {"labels": {"app": "nginx"}},
+                    "spec": {"containers": [{"name": "nginx"}]},
+                },
+            },
+            "Invalid pod spec in statefulset template",
+        ),
+        (
+            {
+                "serviceName": "svc",
+                "replicas": "invalid",
+                "selector": {"matchLabels": {"app": "nginx"}},
+                "template": {
+                    "metadata": {"labels": {"app": "nginx"}},
+                    "spec": {"containers": [{"name": "nginx", "image": "nginx:latest"}]},
+                },
+            },
+            "replicas must be an integer",
+        ),
+        (
+            {
+                "serviceName": "svc",
+                "selector": "invalid",
+                "template": {
+                    "metadata": {"labels": {"app": "nginx"}},
+                    "spec": {"containers": [{"name": "nginx", "image": "nginx:latest"}]},
+                },
+            },
+            "Selector must be a dictionary",
+        ),
+        ("not-a-dict", "must be a dictionary"),
+    ],
+)
+def test_statefulset_invalid_spec(invalid_spec, expected_error):
+    """Test statefulset spec validation raises appropriate errors"""
+    func = getattr(kubernetes, "__dict_to_statefulset_spec")
+    with pytest.raises(CommandExecutionError, match=expected_error):
+        func(invalid_spec)
 
 
 def test_patch_service_handles_source_not_found():

--- a/tests/unit/states/test_kubernetes.py
+++ b/tests/unit/states/test_kubernetes.py
@@ -486,6 +486,97 @@ def test_deployment_present_dry_run_fallback():
             assert "dependencies not created yet" in ret["comment"]
 
 
+def test_statefulset_present_handles_show_statefulset_error():
+    """
+    Test statefulset_present handles CommandExecutionError from show_statefulset
+    """
+    with patch.dict(
+        kubernetes.__salt__,
+        {
+            "kubernetes.show_statefulset": MagicMock(
+                side_effect=CommandExecutionError("Connection failed")
+            )
+        },
+    ):
+        with patch.dict(kubernetes.__opts__, {"test": False}):
+            ret = kubernetes.statefulset_present("test-statefulset")
+
+            assert ret["result"] is False
+            assert "Connection failed" in ret["comment"]
+            assert not ret["changes"]
+
+
+def test_statefulset_present_handles_create_statefulset_error():
+    """
+    Test statefulset_present handles CommandExecutionError from create_statefulset
+    """
+    with patch.dict(
+        kubernetes.__salt__,
+        {
+            "kubernetes.show_statefulset": MagicMock(return_value=None),
+            "kubernetes.create_statefulset": MagicMock(
+                side_effect=CommandExecutionError("Invalid spec")
+            ),
+        },
+    ):
+        with patch.dict(kubernetes.__opts__, {"test": False}):
+            ret = kubernetes.statefulset_present("test-statefulset", spec={"invalid": "spec"})
+
+            assert ret["result"] is False
+            assert "Invalid spec" in ret["comment"]
+
+
+def test_statefulset_present_handles_patch_statefulset_error():
+    """
+    Test statefulset_present handles CommandExecutionError from patch_statefulset
+    """
+    existing_statefulset = {"metadata": {"name": "test"}, "spec": {"replicas": 1}}
+
+    with patch.dict(
+        kubernetes.__salt__,
+        {
+            "kubernetes.show_statefulset": MagicMock(return_value=existing_statefulset),
+            "kubernetes.patch_statefulset": MagicMock(
+                side_effect=CommandExecutionError("Patch failed")
+            ),
+        },
+    ):
+        with patch.dict(kubernetes.__opts__, {"test": False}):
+            ret = kubernetes.statefulset_present("test-statefulset", spec={"replicas": 3})
+
+            assert ret["result"] is False
+            assert "Patch failed" in ret["comment"]
+
+
+def test_statefulset_present_dry_run_fallback():
+    """
+    Test that statefulset_present falls back gracefully when dry_run fails in test mode
+    """
+    with patch.dict(
+        kubernetes.__salt__,
+        {
+            "kubernetes.show_statefulset": MagicMock(return_value=None),
+            "kubernetes.create_statefulset": MagicMock(
+                side_effect=CommandExecutionError("Dry run failed")
+            ),
+        },
+    ):
+        with patch.dict(kubernetes.__opts__, {"test": True}):
+            ret = kubernetes.statefulset_present(
+                "test-statefulset",
+                spec={
+                    "serviceName": "test-service",
+                    "template": {
+                        "spec": {"containers": [{"name": "nginx", "image": "nginx:latest"}]}
+                    },
+                },
+            )
+
+            assert ret["result"] is None
+            assert "Dry run failed" in ret["comment"]
+            assert "dependencies not created yet" in ret["comment"]
+
+
 @pytest.mark.parametrize(
     "state_func,show_func",
     [
@@ -494,6 +585,7 @@ def test_deployment_present_dry_run_fallback():
         ("secret_absent", "show_secret"),
         ("configmap_absent", "show_configmap"),
         ("pod_absent", "show_pod"),
+        ("statefulset_absent", "show_statefulset"),
     ],
 )
 def test_absent_handles_show_error(state_func, show_func):
@@ -519,6 +611,7 @@ def test_absent_handles_show_error(state_func, show_func):
         ("secret_absent", "show_secret", "delete_secret"),
         ("configmap_absent", "show_configmap", "delete_configmap"),
         ("pod_absent", "show_pod", "delete_pod"),
+        ("statefulset_absent", "show_statefulset", "delete_statefulset"),
     ],
 )
 def test_absent_handles_delete_error(state_func, show_func, delete_func):
@@ -548,6 +641,7 @@ def test_absent_handles_delete_error(state_func, show_func, delete_func):
         ("configmap_present", "show_configmap"),
         ("pod_present", "show_pod"),
         ("namespace_present", "show_namespace"),
+        ("statefulset_present", "show_statefulset"),
     ],
 )
 def test_present_handles_show_error(state_func, show_func):


### PR DESCRIPTION
### What does this PR do?
Add StatefulSet lifecycle support in execution and state modules.

### What issues does this PR fix or reference?
Fixes: #23

### Previous Behavior
No support for statefulsets.

### New Behavior
Supports listing, show_, delete_, create, patch_, replace_ statefulsets in the execution module.
Supports _present and _absent functions for statefulsets in the state module.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or new features require tests.**
<!-- Please review the [salt-extensions](https://salt-extensions.github.io/salt-extension-copier/topics/testing/writing.html) and [Salt test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests for your changes. -->
- [x] Docs
- [x] Changelog - https://salt-extensions.github.io/salt-extension-copier/topics/documenting/changelog.html#procedure
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
