### PR TITLE
Added support to manage daemonset resources

### DIFF
--- a/changelog/27.added.feature.md
+++ b/changelog/27.added.feature.md
@@ -1,0 +1,1 @@
+Added support to manage daemonset resources in kubernetes clusters.

--- a/src/saltext/kubernetes/modules/kubernetesmod.py
+++ b/src/saltext/kubernetes/modules/kubernetesmod.py
@@ -572,6 +572,39 @@ def replicasets(namespace="default", **kwargs):
         _cleanup(**cfg)
 
 
+def daemonsets(namespace="default", **kwargs):
+    """
+    .. versionadded:: 2.1.0
+
+    Return a list of kubernetes daemonsets defined in the namespace
+
+    namespace
+        The namespace to list daemonsets from. Defaults to ``default``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' kubernetes.daemonsets
+        salt '*' kubernetes.daemonsets namespace=default
+    """
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.AppsV1Api()
+        api_response = api_instance.list_namespaced_daemon_set(namespace)
+
+        return [
+            daemonset["metadata"]["name"]
+            for daemonset in ApiClient().sanitize_for_serialization(api_response).get("items", [])
+        ]
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return []
+        raise CommandExecutionError(exc) from exc
+    finally:
+        _cleanup(**cfg)
+
+
 def show_deployment(name, namespace="default", **kwargs):
     """
     Return the kubernetes deployment defined by name and namespace
@@ -828,6 +861,39 @@ def show_replicaset(name, namespace="default", **kwargs):
     try:
         api_instance = kubernetes.client.AppsV1Api()
         api_response = api_instance.read_namespaced_replica_set(name, namespace)
+
+        return ApiClient().sanitize_for_serialization(api_response)
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        raise CommandExecutionError(exc) from exc
+    finally:
+        _cleanup(**cfg)
+
+
+def show_daemonset(name, namespace="default", **kwargs):
+    """
+    .. versionadded:: 2.1.0
+
+    Return the kubernetes daemonset defined by name and namespace.
+
+    name
+        The name of the daemonset
+
+    namespace
+        The namespace to look for the daemonset. Defaults to ``default``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' kubernetes.show_daemonset my-daemonset default
+        salt '*' kubernetes.show_daemonset name=my-daemonset namespace=default
+    """
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.AppsV1Api()
+        api_response = api_instance.read_namespaced_daemon_set(name, namespace)
 
         return ApiClient().sanitize_for_serialization(api_response)
     except (ApiException, HTTPError) as exc:
@@ -1153,13 +1219,9 @@ def delete_statefulset(name, namespace="default", wait=False, timeout=60, **kwar
         The namespace to delete the statefulset from. Defaults to ``default``.
 
     wait
-        .. versionadded:: 2.0.0
-
         Wait for statefulset deletion to complete (default: False)
 
     timeout
-        .. versionadded:: 2.0.0
-
         Timeout in seconds to wait for deletion (default: 60)
 
     CLI Example:
@@ -1206,13 +1268,9 @@ def delete_replicaset(name, namespace="default", wait=False, timeout=60, **kwarg
         The namespace to delete the replicaset from. Defaults to ``default``.
 
     wait
-        .. versionadded:: 2.0.0
-
         Wait for replicaset deletion to complete (default: False)
 
     timeout
-        .. versionadded:: 2.0.0
-
         Timeout in seconds to wait for deletion (default: 60)
 
     CLI Example:
@@ -1236,6 +1294,55 @@ def delete_replicaset(name, namespace="default", wait=False, timeout=60, **kwarg
                 api_instance, "replicaset", name, namespace, "deleted", timeout
             ):
                 raise CommandExecutionError(f"Timeout waiting for replicaset {name} to be deleted")
+
+        return ApiClient().sanitize_for_serialization(api_response)
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        raise CommandExecutionError(exc) from exc
+    finally:
+        _cleanup(**cfg)
+
+
+def delete_daemonset(name, namespace="default", wait=False, timeout=60, **kwargs):
+    """
+    .. versionadded:: 2.1.0
+
+    Deletes the kubernetes daemonset defined by name and namespace
+
+    name
+        The name of the daemonset
+
+    namespace
+        The namespace to delete the daemonset from. Defaults to ``default``.
+
+    wait
+        Wait for daemonset deletion to complete (default: False)
+
+    timeout
+        Timeout in seconds to wait for deletion (default: 60)
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' kubernetes.delete_daemonset my-daemonset default
+        salt '*' kubernetes.delete_daemonset name=my-daemonset namespace=default
+    """
+    cfg = _setup_conn(**kwargs)
+    body = kubernetes.client.V1DeleteOptions(orphan_dependents=True)
+
+    try:
+        api_instance = kubernetes.client.AppsV1Api()
+        api_response = api_instance.delete_namespaced_daemon_set(
+            name=name, namespace=namespace, body=body
+        )
+
+        if wait:
+            if not _wait_for_resource_status(
+                api_instance, "daemonset", name, namespace, "deleted", timeout
+            ):
+                raise CommandExecutionError(f"Timeout waiting for daemonset {name} to be deleted")
 
         return ApiClient().sanitize_for_serialization(api_response)
     except (ApiException, HTTPError) as exc:
@@ -1929,27 +2036,16 @@ def create_statefulset(
     saltenv
         Salt environment to pull the source file from
 
-        .. versionchanged:: 2.0.0
-            Defaults to the value of the :conf_minion:`saltenv` minion option or ``base``.
-
     template_context
-        .. versionadded:: 2.0.0
-
         Variables to make available in templated files
 
     dry_run
-        .. versionadded:: 2.0.0
-
         If True, only simulates the creation of the statefulset
 
     wait
-        .. versionadded:: 2.0.0
-
         Wait for statefulset to become ready (default: False)
 
     timeout
-        .. versionadded:: 2.0.0
-
         Timeout in seconds to wait for statefulset (default: 60)
 
     CLI Example:
@@ -2041,23 +2137,15 @@ def create_replicaset(
         Salt environment to pull the source file from
 
     template_context
-        .. versionadded:: 2.0.0
-
         Variables to make available in templated files
 
     dry_run
-        .. versionadded:: 2.0.0
-
         If True, only simulates the creation of the replicaset
 
     wait
-        .. versionadded:: 2.0.0
-
         Wait for replicaset to become ready (default: False)
 
     timeout
-        .. versionadded:: 2.0.0
-
         Timeout in seconds to wait for replicaset (default: 60)
 
     CLI Example:
@@ -2103,6 +2191,104 @@ def create_replicaset(
                 raise CommandExecutionError(f"ReplicaSet {namespace}/{name} not found") from exc
             if exc.status == 409:
                 raise CommandExecutionError(f"ReplicaSet {name} already exists") from exc
+        raise CommandExecutionError(exc) from exc
+    finally:
+        _cleanup(**cfg)
+
+
+def create_daemonset(
+    name,
+    namespace="default",
+    metadata=None,
+    spec=None,
+    source=None,
+    template=None,
+    saltenv=None,
+    template_context=None,
+    dry_run=False,
+    wait=False,
+    timeout=60,
+    **kwargs,
+):
+    """
+    .. versionadded:: 2.1.0
+
+    Creates a daemonset with the specified name, namespace, metadata, and spec.
+
+    name
+        The name of the daemonset
+
+    namespace
+        The namespace to create the daemonset in. Defaults to ``default``.
+
+    metadata
+        DaemonSet metadata dict
+
+    spec
+        DaemonSet spec dict following kubernetes API conventions
+
+    source
+        File path to daemonset definition
+
+    template
+        Template engine to use to render the source file
+
+    saltenv
+        Salt environment to pull the source file from
+
+    template_context
+        Variables to make available in templated files
+
+    dry_run
+        If True, only simulates the creation of the daemonset
+
+    wait
+        Wait for daemonset to become ready (default: False)
+
+    timeout
+        Timeout in seconds to wait for daemonset (default: 60)
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' kubernetes.create_daemonset name=my-ds namespace=default wait=True
+    """
+    body = __create_object_body(
+        kind="DaemonSet",
+        obj_class=kubernetes.client.V1DaemonSet,
+        spec_creator=__dict_to_daemonset_spec,
+        name=name,
+        namespace=namespace,
+        metadata=metadata,
+        spec=spec,
+        source=source,
+        template=template,
+        saltenv=saltenv,
+        template_context=template_context,
+    )
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.AppsV1Api()
+        api_response = api_instance.create_namespaced_daemon_set(
+            namespace, body, dry_run="All" if dry_run else None
+        )
+
+        if wait:
+            if not _wait_for_resource_status(
+                api_instance, "daemonset", name, namespace, "ready", timeout
+            ):
+                raise CommandExecutionError(f"Timeout waiting for daemonset {name} to become ready")
+
+        return ApiClient().sanitize_for_serialization(api_response)
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException):
+            if exc.status == 404:
+                raise CommandExecutionError(f"DaemonSet {namespace}/{name} not found") from exc
+            if exc.status == 409:
+                raise CommandExecutionError(f"DaemonSet {name} already exists") from exc
         raise CommandExecutionError(exc) from exc
     finally:
         _cleanup(**cfg)
@@ -2749,6 +2935,97 @@ def replace_replicaset(
         _cleanup(**cfg)
 
 
+def replace_daemonset(
+    name,
+    namespace,
+    spec,
+    metadata=None,
+    source=None,
+    template=None,
+    saltenv=None,
+    template_context=None,
+    wait=False,
+    timeout=60,
+    **kwargs,
+):
+    """
+    .. versionadded:: 2.1.0
+
+    Replaces an existing daemonset with a new one defined by name and
+    namespace with the specified spec.
+
+    name
+        The name of the daemonset
+
+    namespace
+        The namespace of the daemonset
+
+    spec
+        A dictionary representing the spec of the daemonset
+
+    metadata
+        A dictionary representing the metadata of the daemonset
+
+    source
+        File path to daemonset definition
+
+    template
+        Template engine to use to render the source file
+
+    saltenv
+        Salt environment to pull the source file from
+
+    template_context
+        Variables to make available in templated files
+
+    wait
+        Wait for daemonset to become ready (default: False)
+
+    timeout
+        Timeout in seconds to wait for daemonset (default: 60)
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion1' kubernetes.replace_daemonset \
+            name=my-daemonset namespace=default spec='{"replicas": 3}'
+    """
+    body = __create_object_body(
+        kind="DaemonSet",
+        obj_class=kubernetes.client.V1DaemonSet,
+        spec_creator=__dict_to_daemonset_spec,
+        name=name,
+        namespace=namespace,
+        metadata=metadata,
+        spec=spec,
+        source=source,
+        template=template,
+        saltenv=saltenv,
+        template_context=template_context,
+    )
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.AppsV1Api()
+        api_response = api_instance.replace_namespaced_daemon_set(name, namespace, body)
+
+        if wait:
+            if not _wait_for_resource_status(
+                api_instance, "daemonset", name, namespace, "ready", timeout
+            ):
+                raise CommandExecutionError(f"Timeout waiting for daemonset {name} to become ready")
+
+        return ApiClient().sanitize_for_serialization(api_response)
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            raise CommandExecutionError(f"DaemonSet {namespace}/{name} not found") from exc
+        raise CommandExecutionError(exc) from exc
+    finally:
+        _cleanup(**cfg)
+
+
 def patch_service(
     name,
     namespace,
@@ -3312,6 +3589,97 @@ def patch_replicaset(
         _cleanup(**cfg)
 
 
+def patch_daemonset(
+    name,
+    namespace,
+    patch=None,
+    source=None,
+    template=None,
+    saltenv=None,
+    template_context=None,
+    dry_run=False,
+    wait=False,
+    timeout=60,
+    **kwargs,
+):
+    """
+    .. versionadded:: 2.1.0
+
+    Patches an existing daemonset with the provided patch dictionary.
+
+    name
+        The name of the daemonset
+
+    namespace
+        The namespace of the daemonset
+
+    patch
+        A dictionary representing the patch to apply to the daemonset
+
+    source
+        File path to patch definition
+
+    template
+        Template engine to use to render the source file
+
+    saltenv
+        Salt environment to pull the source file from
+
+    template_context
+        Variables to make available in templated files
+
+    dry_run
+        If True, only simulates the patch without applying it (default: False)
+
+    wait
+        Wait for daemonset to become ready (default: False)
+
+    timeout
+        Timeout in seconds to wait for daemonset (default: 60)
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' kubernetes.patch_daemonset \
+            name=my-daemonset \
+            namespace=default \
+            patch='{"spec": {"replicas": 5}}'
+    """
+    if source:
+        rendered = __read_and_render_yaml_file(source, template, saltenv, template_context)
+        if not isinstance(rendered, dict):
+            raise CommandExecutionError("The source file did not render to a dictionary")
+        patch = rendered
+
+    if not isinstance(patch, dict):
+        raise CommandExecutionError("Patch must be a dictionary")
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.AppsV1Api()
+        api_response = api_instance.patch_namespaced_daemon_set(
+            name, namespace, patch, dry_run="All" if dry_run else None
+        )
+
+        if wait:
+            if not _wait_for_resource_status(
+                api_instance, "daemonset", name, namespace, "ready", timeout
+            ):
+                raise CommandExecutionError(f"Timeout waiting for daemonset {name} to become ready")
+
+        return ApiClient().sanitize_for_serialization(api_response)
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            raise CommandExecutionError(f"DaemonSet {namespace}/{name} not found") from exc
+        if isinstance(exc, ApiException) and exc.status == 409:
+            raise CommandExecutionError(f"Conflict when patching daemonset {name}") from exc
+        raise CommandExecutionError(exc) from exc
+    finally:
+        _cleanup(**cfg)
+
+
 def __is_base64(value):
     """
     Check if a string is base64 encoded by attempting to decode it.
@@ -3846,6 +4214,60 @@ def __dict_to_replicaset_spec(spec):
         raise CommandExecutionError(f"Invalid replicaset spec: {exc}") from exc
 
 
+def __dict_to_daemonset_spec(spec):
+    """
+    .. versionadded:: 2.1.0
+
+    Converts a dictionary into kubernetes V1DaemonSetSpec instance.
+    """
+    if not isinstance(spec, dict):
+        raise CommandExecutionError(
+            f"DaemonSet spec must be a dictionary, not {type(spec).__name__}"
+        )
+
+    processed_spec = spec.copy()
+
+    if "template" not in processed_spec:
+        raise CommandExecutionError("DaemonSet spec must include template with pod specification")
+
+    template = processed_spec["template"]
+    template_metadata = template.get("metadata", {})
+    template_labels = template_metadata.get("labels", {})
+
+    if "selector" not in processed_spec:
+        if not template_labels:
+            raise CommandExecutionError(
+                "Template must include labels when selector is not specified"
+            )
+        processed_spec["selector"] = {"match_labels": template_labels}
+    else:
+        selector = processed_spec["selector"]
+        if not selector or not selector.get("matchLabels"):
+            raise CommandExecutionError("DaemonSet selector must include matchLabels")
+        if not all(template_labels.get(k) == v for k, v in selector["matchLabels"].items()):
+            raise CommandExecutionError("selector.matchLabels must match template metadata.labels")
+
+    if "matchLabels" in processed_spec["selector"]:
+        processed_spec["selector"] = {"match_labels": processed_spec["selector"]["matchLabels"]}
+
+    try:
+        pod_spec = __dict_to_pod_spec(template["spec"])
+    except (CommandExecutionError, ValueError) as exc:
+        raise CommandExecutionError(f"Invalid pod spec in daemonset template: {exc}") from exc
+
+    pod_template = kubernetes.client.V1PodTemplateSpec(
+        metadata=kubernetes.client.V1ObjectMeta(**template_metadata), spec=pod_spec
+    )
+    processed_spec["template"] = pod_template
+
+    processed_spec["selector"] = kubernetes.client.V1LabelSelector(**processed_spec["selector"])
+
+    try:
+        return kubernetes.client.V1DaemonSetSpec(**processed_spec)
+    except (TypeError, ValueError) as exc:
+        raise CommandExecutionError(f"Invalid daemonset spec: {exc}") from exc
+
+
 def __enforce_only_strings_dict(dictionary):
     """
     Returns a dictionary that has string keys and values.
@@ -3880,6 +4302,8 @@ def _wait_for_resource_status(
         Namespace of the resource
 
     expected_status
+        .. versionchanged:: 2.1.0
+
         Expected status to wait for ('created', 'deleted', 'ready')
 
     timeout
@@ -3898,6 +4322,7 @@ def _wait_for_resource_status(
                 method_name = {
                     "statefulset": "read_namespaced_stateful_set",
                     "replicaset": "read_namespaced_replica_set",
+                    "daemonset": "read_namespaced_daemon_set",
                     "configmap": "read_namespaced_config_map",
                 }.get(resource_type, f"read_namespaced_{resource_type}")
 
@@ -3928,6 +4353,7 @@ def _wait_for_resource_status(
         method_name = {
             "statefulset": "list_namespaced_stateful_set",
             "replicaset": "list_namespaced_replica_set",
+            "daemonset": "list_namespaced_daemon_set",
             "configmap": "list_namespaced_config_map",
         }.get(resource_type, f"list_namespaced_{resource_type}")
 

--- a/src/saltext/kubernetes/states/kubernetes.py
+++ b/src/saltext/kubernetes/states/kubernetes.py
@@ -861,6 +861,236 @@ def replicaset_present(
     return ret
 
 
+def daemonset_absent(name, namespace="default", wait=False, timeout=60, **kwargs):
+    """
+    .. versionadded:: 2.1.0
+
+    Ensures that the named daemonset is absent from the given namespace.
+
+    name
+        The name of the daemonset
+
+    namespace
+        The namespace of the daemonset
+
+    wait
+        Wait for daemonset to be deleted (default: False)
+
+    timeout
+        Timeout in seconds to wait for daemonset deletion (default: 60)
+
+        CLI Example:
+
+    .. code-block:: yaml
+
+        my-daemonset:
+          kubernetes.daemonset_absent:
+            namespace: default
+    """
+
+    ret = {"name": name, "changes": {}, "result": False, "comment": ""}
+
+    try:
+        daemonset = __salt__["kubernetes.show_daemonset"](name, namespace, **kwargs)
+
+        if daemonset is None:
+            ret["result"] = True
+            ret["comment"] = "The daemonset does not exist"
+            return ret
+
+        if __opts__["test"]:
+            ret["result"] = None
+            ret["comment"] = "The daemonset is going to be deleted"
+            ret["changes"] = {
+                "old": "present",
+                "new": "absent",
+            }
+            return ret
+
+        __salt__["kubernetes.delete_daemonset"](
+            name, namespace, wait=wait, timeout=timeout, **kwargs
+        )
+
+        ret["result"] = True
+        ret["changes"] = {"old": "present", "new": "absent"}
+        ret["comment"] = f"DaemonSet {name} deleted"
+
+    except CommandExecutionError as err:
+        log.error(str(err), exc_info_on_loglevel=logging.DEBUG)
+        ret["result"] = False
+        ret["comment"] = str(err)
+        ret["changes"] = {}
+
+    return ret
+
+
+def daemonset_present(
+    name,
+    namespace="default",
+    metadata=None,
+    spec=None,
+    source="",
+    template="",
+    template_context=None,
+    wait=False,
+    timeout=60,
+    **kwargs,
+):
+    """
+    .. versionadded:: 2.1.0
+
+    Ensures that the named daemonset is present inside of the specified
+    namespace with the given metadata and spec.
+    If the daemonset exists, it will be patched with the desired state.
+
+    name
+        The name of the daemonset
+
+    namespace
+        The namespace of the daemonset
+
+    metadata
+        Metadata for the daemonset
+
+    spec
+        Specification for the daemonset
+
+    source
+        File path to daemonset definition
+
+    template
+        Template engine to use to render the source file
+
+    saltenv
+        Salt environment to pull the source file from
+
+    template_context
+        Variables to make available in templated files
+
+    wait
+        Wait for daemonset to become ready (default: False)
+
+    timeout
+        Timeout in seconds to wait for daemonset (default: 60)
+
+    CLI Example:
+
+    .. code-block:: yaml
+
+        my-daemonset:
+          kubernetes.daemonset_present:
+            namespace: default
+            metadata:
+              labels:
+                app: my-daemonset
+            spec:
+              replicas: 3
+    """
+    ret = {"name": name, "changes": {}, "result": False, "comment": ""}
+
+    if (metadata or spec) and source:
+        return _error(ret, "'source' cannot be used in combination with 'metadata' or 'spec'")
+
+    if metadata is None:
+        metadata = {}
+
+    if spec is None:
+        spec = {}
+
+    try:
+        daemonset = __salt__["kubernetes.show_daemonset"](name, namespace, **kwargs)
+
+        if daemonset is None:
+            try:
+                res = __salt__["kubernetes.create_daemonset"](
+                    name=name,
+                    namespace=namespace,
+                    metadata=metadata,
+                    spec=spec,
+                    source=source,
+                    template=template,
+                    saltenv=__env__,
+                    template_context=template_context,
+                    dry_run=bool(__opts__["test"]),
+                    wait=wait if not __opts__["test"] else False,
+                    timeout=timeout,
+                    **kwargs,
+                )
+            except CommandExecutionError as err:
+                if not __opts__["test"]:
+                    raise
+                ret["result"] = None
+                ret["comment"] = (
+                    "The daemonset is going to be created. "
+                    f"Dry run failed, possibly due to dependencies not created yet: {err}"
+                )
+                return ret
+
+            ret["changes"] = {"old": {}, "new": res}
+            if __opts__["test"]:
+                ret["result"] = None
+                ret["comment"] = "The daemonset is going to be created"
+            else:
+                ret["result"] = True
+                ret["comment"] = "DaemonSet created"
+            return ret
+
+        if source:
+            patch_kwargs = {
+                "source": source,
+                "template": template,
+                "template_context": template_context,
+            }
+        else:
+            patch_obj = {}
+            if metadata:
+                patch_obj["metadata"] = metadata
+            if spec:
+                patch_obj["spec"] = spec
+            patch_kwargs = {"patch": patch_obj}
+
+        try:
+            res = __salt__["kubernetes.patch_daemonset"](
+                name,
+                namespace,
+                dry_run=bool(__opts__["test"]),
+                wait=wait,
+                timeout=timeout,
+                **patch_kwargs,
+                **kwargs,
+            )
+        except CommandExecutionError as err:
+            if not __opts__["test"]:
+                raise
+            ret["result"] = None
+            ret["comment"] = (
+                "The daemonset is going to be updated. "
+                f"Dry run failed, possibly due to dependencies not created yet: {err}"
+            )
+            return ret
+
+        if res == daemonset:
+            ret["result"] = True
+            ret["comment"] = "The daemonset is already in the desired state"
+            return ret
+
+        ret["changes"] = _changes(daemonset, res)
+        if __opts__["test"]:
+            ret["result"] = None
+            ret["comment"] = "The daemonset is going to be updated"
+        else:
+            ret["result"] = True
+            ret["comment"] = "DaemonSet updated"
+
+    except CommandExecutionError as err:
+        log.error(str(err), exc_info_on_loglevel=logging.DEBUG)
+        ret["result"] = False
+        ret["comment"] = str(err)
+        ret["changes"] = {}
+
+    return ret
+
+
 def service_present(
     name,
     namespace="default",

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -333,6 +333,49 @@ def replicaset(kubernetes_exe, replicaset_spec, request):
         assert kubernetes_exe.show_replicaset(name=name, namespace=namespace) is None
 
 
+@pytest.fixture
+def daemonset_spec():
+    """
+    Fixture providing a basic daemonset spec
+    """
+    return {
+        "selector": {"matchLabels": {"app": "nginx"}},
+        "template": {
+            "metadata": {"labels": {"app": "nginx"}},
+            "spec": {"containers": [{"name": "nginx", "image": "nginx:latest"}]},
+        },
+    }
+
+
+@pytest.fixture(params=[True])
+def daemonset(kubernetes_exe, daemonset_spec, request):
+    """
+    Fixture to create a test daemonset.
+
+    If request.param is True, daemonset is created before the test.
+    If request.param is False, daemonset is not created.
+    """
+    name = random_string("daemonset-", uppercase=False)
+    namespace = "default"
+
+    if request.param:
+        res = kubernetes_exe.create_daemonset(
+            name=name,
+            namespace=namespace,
+            metadata={},
+            spec=daemonset_spec,
+            wait=True,
+        )
+        assert isinstance(res, dict)
+        assert res["metadata"]["name"] == name
+
+    try:
+        yield {"name": name, "namespace": namespace, "spec": daemonset_spec}
+    finally:
+        kubernetes_exe.delete_daemonset(name=name, namespace=namespace, wait=True)
+        assert kubernetes_exe.show_daemonset(name=name, namespace=namespace) is None
+
+
 @pytest.fixture(params=[True])
 def secret(kubernetes_exe, secret_data, request):
     """

--- a/tests/functional/modules/test_kubernetesmod.py
+++ b/tests/functional/modules/test_kubernetesmod.py
@@ -1167,6 +1167,211 @@ def test_list_replicasets_in_nonexistent_namespace(kubernetes, namespace):
     assert res == []
 
 
+def test_daemonsets(kubernetes, daemonset):
+    """
+    Test that the daemonsets function returns a list of daemonsets in the specified namespace
+    """
+    res = kubernetes.daemonsets(daemonset["namespace"])
+    assert isinstance(res, list)
+    assert daemonset["name"] in res
+
+
+@pytest.mark.parametrize("daemonset", [False], indirect=True)
+def test_create_daemonset(kubernetes, daemonset):
+    """
+    Test creating a daemonset returns expected result
+    """
+    res = kubernetes.create_daemonset(
+        name=daemonset["name"],
+        namespace=daemonset["namespace"],
+        metadata={},
+        spec=daemonset["spec"],
+        source=None,
+        template=None,
+        saltenv="base",
+        wait=True,
+    )
+    assert isinstance(res, dict)
+    assert res["metadata"]["name"] == daemonset["name"]
+    assert res["metadata"]["namespace"] == daemonset["namespace"]
+
+
+def test_create_existing_daemonset(kubernetes, daemonset):
+    """
+    Test creating a daemonset that already exists raises appropriate error
+    """
+    with pytest.raises(CommandExecutionError, match=".*already exists.*"):
+        kubernetes.create_daemonset(
+            name=daemonset["name"],
+            namespace=daemonset["namespace"],
+            metadata={},
+            spec=daemonset["spec"],
+            source=None,
+            template=None,
+            saltenv="base",
+            wait=True,
+        )
+
+
+def test_show_daemonset(kubernetes, daemonset):
+    """
+    Test showing a daemonset returns expected result
+    """
+    res = kubernetes.show_daemonset(daemonset["name"], daemonset["namespace"])
+    assert isinstance(res, dict)
+    assert res["metadata"]["name"] == daemonset["name"]
+    assert res["metadata"]["namespace"] == daemonset["namespace"]
+
+
+@pytest.mark.parametrize("daemonset", [False], indirect=True)
+def test_show_nonexistent_daemonset(kubernetes, daemonset):
+    """
+    Test showing a daemonset that doesn't exist returns None
+    """
+    res = kubernetes.show_daemonset(daemonset["name"], daemonset["namespace"])
+    assert res is None
+
+
+def test_replace_daemonset(kubernetes, daemonset):
+    """
+    Test replacing a daemonset with new spec
+    """
+    new_spec = daemonset["spec"].copy()
+    new_spec["template"] = {
+        "metadata": {"labels": {"app": "nginx"}},
+        "spec": {"containers": [{"name": "nginx", "image": "nginx:1.27"}]},
+    }
+
+    res = kubernetes.replace_daemonset(
+        name=daemonset["name"],
+        namespace=daemonset["namespace"],
+        metadata={},
+        spec=new_spec,
+        source=None,
+        template=None,
+        saltenv="base",
+        wait=True,
+    )
+    assert isinstance(res, dict)
+    assert res["spec"]["template"]["spec"]["containers"][0]["image"] == "nginx:1.27"
+
+
+@pytest.mark.parametrize("daemonset", [False], indirect=True)
+def test_replace_nonexistent_daemonset(kubernetes, daemonset):
+    """
+    Test replacing a daemonset that doesn't exist raises appropriate error
+    """
+    with pytest.raises(CommandExecutionError, match=".*not found.*"):
+        kubernetes.replace_daemonset(
+            name=daemonset["name"],
+            namespace=daemonset["namespace"],
+            metadata={},
+            spec=daemonset["spec"],
+            source=None,
+            template=None,
+            saltenv="base",
+            wait=True,
+        )
+
+
+def test_patch_daemonset(kubernetes, daemonset):
+    """
+    Test patching a daemonset to update pod template metadata.
+    """
+    patch = {
+        "spec": {
+            "template": {
+                "metadata": {
+                    "annotations": {
+                        "patched": "true",
+                    }
+                }
+            }
+        }
+    }
+    res = kubernetes.patch_daemonset(
+        daemonset["name"],
+        daemonset["namespace"],
+        patch,
+        wait=True,
+        timeout=120,
+    )
+    assert isinstance(res, dict)
+    assert res["spec"]["template"]["metadata"]["annotations"]["patched"] == "true"
+
+
+@pytest.mark.parametrize("daemonset", [False], indirect=True)
+def test_patch_nonexistent_daemonset(kubernetes, daemonset):
+    """
+    Test patching a daemonset that doesn't exist raises appropriate error
+    """
+    patch = {"spec": {"template": {"metadata": {"annotations": {"patched": "true"}}}}}
+    with pytest.raises(CommandExecutionError, match=".*not found.*"):
+        kubernetes.patch_daemonset(
+            daemonset["name"],
+            daemonset["namespace"],
+            patch,
+            wait=True,
+            timeout=120,
+        )
+
+
+def test_patch_preserves_spec_replace_is_full_daemonset(kubernetes, daemonset):
+    """
+    Test that patch merges into spec while replace overwrites it entirely.
+    """
+    kubernetes.patch_daemonset(
+        daemonset["name"],
+        daemonset["namespace"],
+        {"spec": {"template": {"metadata": {"annotations": {"note": "patched"}}}}},
+        wait=True,
+    )
+    res = kubernetes.show_daemonset(daemonset["name"], daemonset["namespace"])
+    assert res["spec"]["template"]["metadata"]["annotations"]["note"] == "patched"
+
+    kubernetes.replace_daemonset(
+        name=daemonset["name"],
+        namespace=daemonset["namespace"],
+        metadata={},
+        spec=daemonset["spec"],
+        source=None,
+        template=None,
+        saltenv="base",
+        wait=True,
+    )
+    res = kubernetes.show_daemonset(daemonset["name"], daemonset["namespace"])
+    assert not res["spec"]["template"]["metadata"].get("annotations", {})
+
+
+def test_delete_existing_daemonset(kubernetes, daemonset):
+    """
+    Test deleting a daemonset that exists returns expected result
+    """
+    res = kubernetes.delete_daemonset(daemonset["name"], daemonset["namespace"], wait=True)
+    assert isinstance(res, dict)
+
+    deleted_daemonset = kubernetes.show_daemonset(daemonset["name"], daemonset["namespace"])
+    assert deleted_daemonset is None
+
+
+@pytest.mark.parametrize("daemonset", [False], indirect=True)
+def test_delete_nonexistent_daemonset(kubernetes, daemonset):
+    """
+    Test deleting a daemonset that doesn't exist returns None
+    """
+    res = kubernetes.delete_daemonset(daemonset["name"], daemonset["namespace"])
+    assert res is None
+
+
+@pytest.mark.parametrize("namespace", [False], indirect=True)
+def test_list_daemonsets_in_nonexistent_namespace(kubernetes, namespace):
+    """
+    Test listing daemonsets in a namespace that doesn't exist returns empty list
+    """
+    res = kubernetes.daemonsets(namespace)
+    assert res == []
+
+
 @pytest.fixture
 def service_spec(request):
     """

--- a/tests/functional/states/test_kubernetes.py
+++ b/tests/functional/states/test_kubernetes.py
@@ -950,6 +950,209 @@ def test_replicaset_absent_idempotency(kubernetes, replicaset, testmode):
 
 
 @pytest.fixture
+def daemonset_template(state_tree):
+    sls = "k8s/daemonset-template"
+    contents = dedent("""
+        apiVersion: apps/v1
+        kind: DaemonSet
+        metadata:
+          name: {{ name }}
+          namespace: {{ namespace }}
+          labels: {{ labels | json }}
+        spec:
+          selector:
+            matchLabels:
+              app: {{ app_label }}
+          template:
+            metadata:
+              labels: {{ labels | json }}
+            spec:
+              containers:
+              - name: {{ name }}
+                image: {{ image }}
+                ports:
+                - containerPort: 80
+        """).strip()
+
+    with pytest.helpers.temp_file(f"{sls}.yml.jinja", contents, state_tree):
+        yield f"salt://{sls}.yml.jinja"
+
+
+@pytest.mark.parametrize("daemonset", [False], indirect=True)
+def test_daemonset_present(kubernetes, daemonset, testmode, kubernetes_exe):
+    """
+    Test kubernetes.daemonset_present creates a daemonset
+    """
+    ret = kubernetes.daemonset_present(
+        name=daemonset["name"],
+        namespace=daemonset["namespace"],
+        spec=daemonset["spec"],
+        wait=True,
+        test=testmode,
+    )
+
+    assert ret.result in (None, True)
+    assert (ret.result is None) is testmode
+    if not testmode:
+        daemonset_state = kubernetes_exe.show_daemonset(
+            name=daemonset["name"], namespace=daemonset["namespace"]
+        )
+        assert daemonset_state["metadata"]["name"] == daemonset["name"]
+    else:
+        daemonset_state = kubernetes_exe.show_daemonset(
+            name=daemonset["name"], namespace=daemonset["namespace"]
+        )
+        assert daemonset_state is None
+
+
+def test_daemonset_present_idempotency(kubernetes, daemonset, testmode):
+    """
+    Test kubernetes.daemonset_present is idempotent
+    """
+    ret = kubernetes.daemonset_present(
+        name=daemonset["name"],
+        namespace=daemonset["namespace"],
+        spec=daemonset["spec"],
+        wait=True,
+        test=testmode,
+    )
+    assert ret.result is True
+    assert "The daemonset is already in the desired state" in ret.comment
+    assert not ret.changes
+
+
+def test_daemonset_present_patch(kubernetes, daemonset, kubernetes_exe, testmode):
+    """
+    Test kubernetes.daemonset_present patches a daemonset
+    """
+    daemonset["spec"]["template"]["spec"]["containers"][0]["image"] = "nginx:1.27"
+
+    ret = kubernetes.daemonset_present(
+        name=daemonset["name"],
+        namespace=daemonset["namespace"],
+        spec=daemonset["spec"],
+        wait=True,
+        test=testmode,
+    )
+    assert ret.result in (None, True)
+    assert (ret.result is None) is testmode
+
+    daemonset_state = kubernetes_exe.show_daemonset(
+        name=daemonset["name"], namespace=daemonset["namespace"]
+    )
+    assert daemonset_state["metadata"]["name"] == daemonset["name"]
+    assert (
+        daemonset_state["spec"]["template"]["spec"]["containers"][0]["image"] == "nginx:1.27"
+    ) is not testmode
+
+
+def test_daemonset_present_patch_source(kubernetes, daemonset, daemonset_template, kubernetes_exe):
+    """
+    Test kubernetes.daemonset_present patches a daemonset using source/template
+    """
+    template_context = {
+        "name": daemonset["name"],
+        "namespace": daemonset["namespace"],
+        "app_label": "nginx",
+        "image": "nginx:1.27",
+        "labels": {"app": "nginx"},
+    }
+
+    ret = kubernetes.daemonset_present(
+        name=daemonset["name"],
+        namespace=daemonset["namespace"],
+        source=daemonset_template,
+        template="jinja",
+        template_context=template_context,
+        wait=True,
+    )
+    assert ret.result is True
+
+    daemonset_state = kubernetes_exe.show_daemonset(
+        name=daemonset["name"], namespace=daemonset["namespace"]
+    )
+    assert daemonset_state["metadata"]["name"] == daemonset["name"]
+    assert daemonset_state["spec"]["template"]["spec"]["containers"][0]["image"] == "nginx:1.27"
+
+
+@pytest.mark.parametrize("daemonset", [False], indirect=True)
+def test_daemonset_present_template_context(
+    kubernetes, daemonset, daemonset_template, kubernetes_exe
+):
+    """
+    Test kubernetes.daemonset_present with template_context
+    """
+    template_context = {
+        "name": daemonset["name"],
+        "namespace": daemonset["namespace"],
+        "app_label": "test",
+        "image": "nginx:latest",
+        "labels": {"app": "test"},
+    }
+
+    ret = kubernetes.daemonset_present(
+        name=daemonset["name"],
+        namespace=daemonset["namespace"],
+        source=daemonset_template,
+        template="jinja",
+        template_context=template_context,
+        wait=True,
+    )
+    assert ret.result is True
+
+    daemonset_state = kubernetes_exe.show_daemonset(
+        name=daemonset["name"], namespace=daemonset["namespace"]
+    )
+    assert daemonset_state["metadata"]["name"] == daemonset["name"]
+    assert daemonset_state["metadata"]["labels"]["app"] == "test"
+    assert daemonset_state["spec"]["selector"]["matchLabels"]["app"] == "test"
+    assert daemonset_state["spec"]["template"]["spec"]["containers"][0]["image"] == "nginx:latest"
+
+
+def test_daemonset_absent(kubernetes, daemonset, testmode, kubernetes_exe):
+    """
+    Test kubernetes.daemonset_absent deletes a daemonset
+    """
+    ret = kubernetes.daemonset_absent(
+        name=daemonset["name"],
+        namespace=daemonset["namespace"],
+        wait=True,
+        test=testmode,
+    )
+
+    assert ret.result in (None, True)
+    assert (ret.result is None) is testmode
+
+    if not testmode:
+        assert ret.changes["new"] == "absent"
+        daemonset_state = kubernetes_exe.show_daemonset(
+            name=daemonset["name"], namespace=daemonset["namespace"]
+        )
+        assert daemonset_state is None
+    else:
+        assert ret.changes["new"] == "absent"
+        assert "The daemonset is going to be deleted" in ret.comment
+        daemonset_state = kubernetes_exe.show_daemonset(
+            name=daemonset["name"], namespace=daemonset["namespace"]
+        )
+        assert daemonset_state is not None
+        assert daemonset_state["metadata"]["name"] == daemonset["name"]
+
+
+@pytest.mark.parametrize("daemonset", [False], indirect=True)
+def test_daemonset_absent_idempotency(kubernetes, daemonset, testmode):
+    """
+    Test kubernetes.daemonset_absent is idempotent
+    """
+    ret = kubernetes.daemonset_absent(
+        name=daemonset["name"], namespace=daemonset["namespace"], wait=True, test=testmode
+    )
+    assert ret.result is True
+    assert "does not exist" in ret.comment
+    assert not ret.changes
+
+
+@pytest.fixture
 def secret_data():
     return {"key": "value"}, "Opaque"
 

--- a/tests/unit/modules/test_kubernetesmod.py
+++ b/tests/unit/modules/test_kubernetesmod.py
@@ -439,6 +439,45 @@ def test_replicasets_handles_empty_response(mock_api):
         assert result == []
 
 
+def test_daemonsets_handles_api_exception(mock_api):
+    """
+    Test that daemonsets() handles ApiException properly
+    """
+    mock_api.client.AppsV1Api().list_namespaced_daemon_set.side_effect = ApiException(
+        status=500, reason="Internal Server Error"
+    )
+
+    with pytest.raises(CommandExecutionError):
+        kubernetes.daemonsets()
+
+
+def test_daemonsets_handles_404_gracefully(mock_api):
+    """
+    Test that daemonsets() returns empty list for 404 (namespace not found)
+    """
+    mock_api.client.AppsV1Api().list_namespaced_daemon_set.side_effect = ApiException(
+        status=404, reason="Not Found"
+    )
+
+    result = kubernetes.daemonsets("nonexistent-namespace")
+    assert result == []
+
+
+def test_daemonsets_handles_empty_response(mock_api):
+    """
+    Test that daemonsets() handles response with no items gracefully
+    """
+    with patch("saltext.kubernetes.modules.kubernetesmod.ApiClient") as mock_api_client_class:
+        mock_api_client_instance = Mock()
+        mock_api_client_instance.sanitize_for_serialization.return_value = {}
+        mock_api_client_class.return_value = mock_api_client_instance
+
+        mock_api.client.AppsV1Api().list_namespaced_daemon_set.return_value = Mock()
+
+        result = kubernetes.daemonsets()
+        assert result == []
+
+
 def test_patch_deployment_validates_patch_parameter():
     """
     Test patch_deployment raises error when patch is not a dictionary
@@ -461,6 +500,14 @@ def test_patch_replicaset_validates_patch_parameter():
     """
     with pytest.raises(CommandExecutionError, match="Patch must be a dictionary"):
         kubernetes.patch_replicaset("test", "default", patch="not-a-dict")
+
+
+def test_patch_daemonset_validates_patch_parameter():
+    """
+    Test patch_daemonset raises error when patch is not a dictionary
+    """
+    with pytest.raises(CommandExecutionError, match="Patch must be a dictionary"):
+        kubernetes.patch_daemonset("test", "default", patch="not-a-dict")
 
 
 def test_patch_deployment_handles_missing_deployment(mock_api):
@@ -500,6 +547,18 @@ def test_patch_replicaset_handles_missing_replicaset(mock_api):
         kubernetes.patch_replicaset("nonexistent", "default", patch={"spec": {"replicas": 3}})
 
 
+def test_patch_daemonset_handles_missing_daemonset(mock_api):
+    """
+    Test patch_daemonset handles case where daemonset doesn't exist
+    """
+    mock_api.client.AppsV1Api().patch_namespaced_daemon_set.side_effect = ApiException(
+        status=404, reason="Not Found"
+    )
+
+    with pytest.raises(CommandExecutionError):
+        kubernetes.patch_daemonset("nonexistent", "default", patch={"spec": {"template": {}}})
+
+
 def test_delete_deployment_handles_already_deleted(mock_api):
     """
     Test delete_deployment returns None when deployment is already deleted (404)
@@ -533,6 +592,18 @@ def test_delete_replicaset_handles_already_deleted(mock_api):
         status=404, reason="Not Found"
     )
     result = kubernetes.delete_replicaset("already-deleted", "default")
+    assert result is None
+
+
+def test_delete_daemonset_handles_already_deleted(mock_api):
+    """
+    Test delete_daemonset returns None when daemonset is already deleted (404)
+    """
+    mock_api.client.V1DeleteOptions.return_value = MagicMock()
+    mock_api.client.AppsV1Api.return_value.delete_namespaced_daemon_set.side_effect = ApiException(
+        status=404, reason="Not Found"
+    )
+    result = kubernetes.delete_daemonset("already-deleted", "default")
     assert result is None
 
 
@@ -655,6 +726,47 @@ def test_patch_replicaset_handles_invalid_yaml():
             with patch.dict(kubernetes.__opts__, {"saltenv": "base"}):
                 with pytest.raises(CommandExecutionError, match="did not render to a dictionary"):
                     kubernetes.patch_replicaset(
+                        "test", "default", patch=None, source="salt://invalid.yml"
+                    )
+    finally:
+        os.unlink(tmpfile)
+
+
+def test_patch_daemonset_handles_source_rendering_error():
+    """
+    Test patch_daemonset handles template rendering errors gracefully
+    """
+    with patch.dict(
+        kubernetes.__salt__,
+        {
+            "cp.cache_file": MagicMock(return_value=None),
+        },
+    ):
+        with patch.dict(kubernetes.__opts__, {"saltenv": "base"}):
+            with pytest.raises(CommandExecutionError, match="Source file.*not found"):
+                kubernetes.patch_daemonset(
+                    "test", "default", patch=None, source="salt://bad-template.yml"
+                )
+
+
+def test_patch_daemonset_handles_invalid_yaml():
+    """
+    Test patch_daemonset raises error when source file does not render to a dictionary
+    """
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+        f.write("- item1\n- item2\n")
+        tmpfile = f.name
+
+    try:
+        with patch.dict(
+            kubernetes.__salt__,
+            {
+                "cp.cache_file": MagicMock(return_value=tmpfile),
+            },
+        ):
+            with patch.dict(kubernetes.__opts__, {"saltenv": "base"}):
+                with pytest.raises(CommandExecutionError, match="did not render to a dictionary"):
+                    kubernetes.patch_daemonset(
                         "test", "default", patch=None, source="salt://invalid.yml"
                     )
     finally:
@@ -830,6 +942,20 @@ def test_create_replicaset_handles_conflict(mock_api):
             kubernetes.create_replicaset("test", "default", {}, {}, None, None, None)
 
 
+def test_create_daemonset_handles_conflict(mock_api):
+    """
+    Test create_daemonset raises for 409 conflict (already exists)
+    """
+    with patch(
+        "saltext.kubernetes.modules.kubernetesmod.__create_object_body", return_value=MagicMock()
+    ):
+        mock_api.client.AppsV1Api().create_namespaced_daemon_set.side_effect = ApiException(
+            status=409, reason="AlreadyExists"
+        )
+        with pytest.raises(CommandExecutionError, match="already exists"):
+            kubernetes.create_daemonset("test", "default", {}, {}, None, None, None)
+
+
 def test_patch_deployment_handles_conflict(mock_api):
     """
     Test patch_deployment raises for 409 conflict (concurrent modification)
@@ -872,6 +998,17 @@ def test_patch_replicaset_handles_conflict(mock_api):
     )
     with pytest.raises(CommandExecutionError, match="Conflict when patching"):
         kubernetes.patch_replicaset("test", "default", patch={"spec": {"replicas": 3}})
+
+
+def test_patch_daemonset_handles_conflict(mock_api):
+    """
+    Test patch_daemonset raises for 409 conflict (concurrent modification)
+    """
+    mock_api.client.AppsV1Api().patch_namespaced_daemon_set.side_effect = ApiException(
+        status=409, reason="Conflict"
+    )
+    with pytest.raises(CommandExecutionError, match="Conflict when patching"):
+        kubernetes.patch_daemonset("test", "default", patch={"spec": {"template": {}}})
 
 
 @pytest.mark.parametrize(
@@ -958,6 +1095,34 @@ def test_statefulset_invalid_spec(invalid_spec, expected_error):
 def test_replicaset_invalid_spec(invalid_spec, expected_error):
     """Test replicaset spec validation raises appropriate errors"""
     func = getattr(kubernetes, "__dict_to_replicaset_spec")
+    with pytest.raises(CommandExecutionError, match=expected_error):
+        func(invalid_spec)
+
+
+@pytest.mark.parametrize(
+    "invalid_spec,expected_error",
+    [
+        ({"selector": {"matchLabels": {"app": "nginx"}}}, "template"),
+        (
+            {
+                "selector": {"matchLabels": {"app": "different"}},
+                "template": {
+                    "metadata": {"labels": {"app": "nginx"}},
+                    "spec": {"containers": [{"name": "nginx", "image": "nginx:latest"}]},
+                },
+            },
+            "must match template",
+        ),
+        (
+            {"template": {"spec": {"containers": [{"name": "nginx", "image": "nginx:latest"}]}}},
+            "Template must include labels",
+        ),
+        ("not-a-dict", "must be a dictionary"),
+    ],
+)
+def test_daemonset_invalid_spec(invalid_spec, expected_error):
+    """Test daemonset spec validation raises appropriate errors"""
+    func = getattr(kubernetes, "__dict_to_daemonset_spec")
     with pytest.raises(CommandExecutionError, match=expected_error):
         func(invalid_spec)
 

--- a/tests/unit/states/test_kubernetes.py
+++ b/tests/unit/states/test_kubernetes.py
@@ -669,6 +669,107 @@ def test_replicaset_present_dry_run_fallback():
             assert "dependencies not created yet" in ret["comment"]
 
 
+def test_daemonset_present_handles_show_daemonset_error():
+    """
+    Test daemonset_present handles CommandExecutionError from show_daemonset
+    """
+    with patch.dict(
+        kubernetes.__salt__,
+        {
+            "kubernetes.show_daemonset": MagicMock(
+                side_effect=CommandExecutionError("Connection failed")
+            )
+        },
+    ):
+        with patch.dict(kubernetes.__opts__, {"test": False}):
+            ret = kubernetes.daemonset_present("test-daemonset")
+
+            assert ret["result"] is False
+            assert "Connection failed" in ret["comment"]
+            assert not ret["changes"]
+
+
+def test_daemonset_present_handles_create_daemonset_error():
+    """
+    Test daemonset_present handles CommandExecutionError from create_daemonset
+    """
+    with patch.dict(
+        kubernetes.__salt__,
+        {
+            "kubernetes.show_daemonset": MagicMock(return_value=None),
+            "kubernetes.create_daemonset": MagicMock(
+                side_effect=CommandExecutionError("Invalid spec")
+            ),
+        },
+    ):
+        with patch.dict(kubernetes.__opts__, {"test": False}):
+            ret = kubernetes.daemonset_present("test-daemonset", spec={"invalid": "spec"})
+
+            assert ret["result"] is False
+            assert "Invalid spec" in ret["comment"]
+
+
+def test_daemonset_present_handles_patch_daemonset_error():
+    """
+    Test daemonset_present handles CommandExecutionError from patch_daemonset
+    """
+    existing_daemonset = {"metadata": {"name": "test"}, "spec": {"template": {}}}
+
+    with patch.dict(
+        kubernetes.__salt__,
+        {
+            "kubernetes.show_daemonset": MagicMock(return_value=existing_daemonset),
+            "kubernetes.patch_daemonset": MagicMock(
+                side_effect=CommandExecutionError("Patch failed")
+            ),
+        },
+    ):
+        with patch.dict(kubernetes.__opts__, {"test": False}):
+            ret = kubernetes.daemonset_present(
+                "test-daemonset",
+                spec={
+                    "selector": {"matchLabels": {"app": "test"}},
+                    "template": {
+                        "metadata": {"labels": {"app": "test"}},
+                        "spec": {"containers": [{"name": "nginx", "image": "nginx:latest"}]},
+                    },
+                },
+            )
+
+            assert ret["result"] is False
+            assert "Patch failed" in ret["comment"]
+
+
+def test_daemonset_present_dry_run_fallback():
+    """
+    Test that daemonset_present falls back gracefully when dry_run fails in test mode
+    """
+    with patch.dict(
+        kubernetes.__salt__,
+        {
+            "kubernetes.show_daemonset": MagicMock(return_value=None),
+            "kubernetes.create_daemonset": MagicMock(
+                side_effect=CommandExecutionError("Dry run failed")
+            ),
+        },
+    ):
+        with patch.dict(kubernetes.__opts__, {"test": True}):
+            ret = kubernetes.daemonset_present(
+                "test-daemonset",
+                spec={
+                    "selector": {"matchLabels": {"app": "test"}},
+                    "template": {
+                        "metadata": {"labels": {"app": "test"}},
+                        "spec": {"containers": [{"name": "nginx", "image": "nginx:latest"}]},
+                    },
+                },
+            )
+
+            assert ret["result"] is None
+            assert "Dry run failed" in ret["comment"]
+            assert "dependencies not created yet" in ret["comment"]
+
+
 @pytest.mark.parametrize(
     "state_func,show_func",
     [
@@ -679,6 +780,7 @@ def test_replicaset_present_dry_run_fallback():
         ("pod_absent", "show_pod"),
         ("statefulset_absent", "show_statefulset"),
         ("replicaset_absent", "show_replicaset"),
+        ("daemonset_absent", "show_daemonset"),
     ],
 )
 def test_absent_handles_show_error(state_func, show_func):
@@ -706,6 +808,7 @@ def test_absent_handles_show_error(state_func, show_func):
         ("pod_absent", "show_pod", "delete_pod"),
         ("statefulset_absent", "show_statefulset", "delete_statefulset"),
         ("replicaset_absent", "show_replicaset", "delete_replicaset"),
+        ("daemonset_absent", "show_daemonset", "delete_daemonset"),
     ],
 )
 def test_absent_handles_delete_error(state_func, show_func, delete_func):
@@ -737,6 +840,7 @@ def test_absent_handles_delete_error(state_func, show_func, delete_func):
         ("namespace_present", "show_namespace"),
         ("statefulset_present", "show_statefulset"),
         ("replicaset_present", "show_replicaset"),
+        ("daemonset_present", "show_daemonset"),
     ],
 )
 def test_present_handles_show_error(state_func, show_func):


### PR DESCRIPTION
### What does this PR do?
Add ReplicaSet lifecycle support in execution and state modules.

### What issues does this PR fix or reference?
Fixes: #27 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or new features require tests.**
<!-- Please review the [salt-extensions](https://salt-extensions.github.io/salt-extension-copier/topics/testing/writing.html) and [Salt test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests for your changes. -->
- [x] Docs
- [x] Changelog - https://salt-extensions.github.io/salt-extension-copier/topics/documenting/changelog.html#procedure
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
