### PR TITLE
Increase timeout from 45 to 60 minutes

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -13,7 +13,7 @@ jobs:
     # land in the 28-31 minute range; 3006 was hitting 29:58 right at the
     # cap. Submit the same bump upstream to salt-extension-copier so the
     # next ``copier update`` doesn't revert it.
-    timeout-minutes: 45
+    timeout-minutes: 60
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
### What does this PR do?
Increases test timeout to 60

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or new features require tests.**
<!-- Please review the [salt-extensions](https://salt-extensions.github.io/salt-extension-copier/topics/testing/writing.html) and [Salt test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests for your changes. -->
- [x] Docs
- [x] Changelog - https://salt-extensions.github.io/salt-extension-copier/topics/documenting/changelog.html#procedure
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
